### PR TITLE
adjusted card widths for better mobile layout

### DIFF
--- a/src/components/Sobre.tsx
+++ b/src/components/Sobre.tsx
@@ -6,32 +6,31 @@ export default function Sobre() {
   return (
     <section id="sobre" className="py-20 bg-AzulMeiaNoite flex w-full overflow-hidden relative">
       <DynamicGrid cellSize={50} className="opacity-5 z-0" numberOfCells={50}/>
-      
       <div className="container mx-auto px-12">
         <h2 className="text-1xl font-semibold text-center text-AzulCeu font-poppins mb-2">Sobre Nós</h2>
-        <p className="text-3xl font-semibold text-center text-Branco font-poppins mb-10">
+        <p className="text-3xl font-semibold text-center text-Branco font-poppins mb-16">
           Aulas, Palestras, Mentorias e muito mais
         </p>
 
         <div className="gap-4 px-4 lg:px-24">
-          <div className="flex gap-2 lg:gap-4">
-            <div className="bg-VerdeMenta p-4 lg:p-10 rounded-2xl shadow-lg transform transition-transform duration-500 hover:scale-[1.02] hover:z-10">
+          <div className="flex flex-col lg:flex-row gap-4">
+            <div className="bg-VerdeMenta p-4 lg:p-10 rounded-2xl shadow-lg lg:flex-[4] transform transition-transform duration-500 hover:scale-[1.02] hover:z-10">
               <h3 className="font-poppins font-extrabold text-xl text-BrancoCreme lg:text-3xl mb-2 mt-2 lg:mb-4 lg:mt-2">
                 Como o TRILHA surgiu?
               </h3>
               <p className="text-BrancoCreme mb-4 text-sm lg:text-xl font-bold font-spaceGrotesk">
                 O TRILHA surgiu como uma iniciativa de alunos da UFPB para apoiar estudantes dos primeiros períodos do Centro de Informática.
               </p>
-                <button 
+              <button 
                 className="px-[10px] text-sm py-1 lg:px-4 lg:py-2 bg-AzulMeiaNoite text-BrancoCreme font-semibold rounded-md hover:bg-Branco hover:text-VerdeMenta duration-500"
                 onClick={() => document.getElementById('quem-somos')?.scrollIntoView({ behavior: 'smooth' })}
                 >
                 Conheça nosso time
-                </button>
+              </button>
               <img className="rounded-xl mt-4 mb-2 lg:mt-4" src="trilha2024.JPG" alt="imagem palestra" />
             </div>
 
-            <div className="bg-AzulEletrico p-4 lg:p-10 rounded-2xl shadow-lg flex-grow transform transition-transform duration-500 hover:scale-[1.02] hover:z-10">
+            <div className="bg-AzulEletrico p-4 lg:p-10 rounded-2xl shadow-lg flex-grow lg:flex-[5] transform transition-transform duration-500 hover:scale-[1.02] hover:z-10">
               <img className="rounded-xl lg:mt-4" src="aulas.jpeg" alt="imagem aulas" />
               <h3 className="font-poppins font-extrabold text-xl lg:text-3xl text-BrancoCreme mb-2 mt-2 lg:mb-4 lg:mt-4">
                 Como são as aulas?
@@ -42,8 +41,8 @@ export default function Sobre() {
             </div>
           </div>
 
-          <div className="flex gap-2 lg:gap-4 pt-4">
-            <div className="bg-AzulEletrico p-4 lg:p-10 rounded-2xl shadow-lg flex-grow transform transition-transform duration-500 hover:scale-[1.02] hover:z-10">
+          <div className="flex flex-col lg:flex-row gap-4 pt-4">
+            <div className="bg-AzulEletrico p-4 lg:p-10 rounded-2xl shadow-lg flex-grow lg:flex-[12] transform transition-transform duration-500 hover:scale-[1.02] hover:z-10">
               <h3 className="font-poppins font-extrabold text-xl lg:text-3xl text-BrancoCreme mb-2 mt-2 lg:mb-4 lg:mt-2">
                 Palestras e Eventos
               </h3>
@@ -53,7 +52,7 @@ export default function Sobre() {
               </p>
             </div>
 
-            <div className="bg-AzulCeu p-4 lg:p-10 rounded-2xl shadow-lg flex-grow transform transition-transform duration-500 hover:scale-[1.02] hover:z-10">
+            <div className="bg-AzulCeu p-4 lg:p-10 rounded-2xl shadow-lg flex-grow lg:flex-[11] transform transition-transform duration-500 hover:scale-[1.02] hover:z-10">
               <h3 className="font-poppins font-extrabold text-xl lg:text-3xl text-BrancoCreme mb-2 mt-2 lg:mb-4 lg:mt-2">
                 Quais são os nossos objetivos?
               </h3>


### PR DESCRIPTION
I created a flex layout that maintains the asymmetric design on larger devices while displaying in a single column on mobile. This way, we can preserve the unique design while ensuring that the content and images are still readable and well-presented when accessing the website from a smartphone.
![Screenshot 2025-01-11 165059](https://github.com/user-attachments/assets/243e7fbe-cbcc-433f-b262-4af243a808a8)
![Screenshot 2025-01-11 165140](https://github.com/user-attachments/assets/7749e9a6-9bbb-46d1-9389-497428b72dd8)