### PR TITLE
Add hackathons section

### DIFF
--- a/src/app/classes/[class]/page.tsx
+++ b/src/app/classes/[class]/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+import Navbar from '@/components/NavBar';
+import Footer from '@/components/Footer';
+import HackathonsSection from '@/components/HackathonsSection';
+import { classes } from '@/data/classes';
+import { hackathons } from '@/data/hackathons';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useTranslatedPeople } from '@/data/people-i18n';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import { AnimatedTooltip } from '@/components/ui/animated-tooltip';
+
+export default function ClassPage({ params }: { params: { class: string } }) {
+  const { t } = useTranslation();
+  const { translatePerson } = useTranslatedPeople();
+
+  const classInfo = classes.find((c) => c.id === params.class);
+  if (!classInfo) return notFound();
+
+  const organizers = classInfo.organizers.map((p, index) => {
+    const tr = translatePerson(p);
+    return { id: index, name: tr.name, designation: tr.role, image: tr.photo, link: tr.link };
+  });
+
+  const students = classInfo.students.map((p) => {
+    const tr = translatePerson(p);
+    return { name: tr.name, course: tr.course, photo: tr.photo, link: tr.link, role: tr.role };
+  });
+
+  const hackathon = hackathons.find((h) => h.class === classInfo.id);
+
+  return (
+    <div className="bg-Branco min-h-screen">
+      <Navbar />
+      <section className="py-20 px-4 md:px-28 flex flex-col gap-8">
+        <h1 className="text-3xl font-bold text-center text-AzulMeiaNoite font-poppins">
+          {t(classInfo.titleKey)}
+        </h1>
+        <p className="text-center font-spaceGrotesk text-AzulMeiaNoite max-w-3xl mx-auto">
+          {t(classInfo.descriptionKey)}
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {classInfo.images.map((img, idx) => (
+            <Image
+              key={idx}
+              src={`/${img}`}
+              alt={classInfo.id}
+              width={600}
+              height={400}
+              className="rounded-lg object-cover"
+            />
+          ))}
+        </div>
+        <div className="flex flex-col items-center gap-4">
+          <h2 className="text-2xl font-semibold">{t('turmaSection.organization')}</h2>
+          <AnimatedTooltip items={organizers} />
+        </div>
+        <div className="flex flex-col items-center gap-4">
+          <h2 className="text-2xl font-semibold">{t('turmaSection.students')}</h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+            {students.map((s, i) => (
+              <div key={i} className="flex flex-col items-center">
+                <Image src={s.photo} alt={s.name} height={200} width={200} className="rounded-full w-24 h-24" />
+                <p className="text-sm text-center font-bold">{s.name.split(' ').slice(0,2).join(' ')}</p>
+                <p className="text-xs text-center">{s.course}</p>
+                <p className="text-xs text-center">{s.role}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+        {hackathon && <HackathonsSection hackathonsList={[hackathon]} />}
+      </section>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/hackathons/[project]/page.tsx
+++ b/src/app/hackathons/[project]/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+import Navbar from '@/components/NavBar';
+import Footer from '@/components/Footer';
+import { hackathons } from '@/data/hackathons';
+import { useTranslatedPeople } from '@/data/people-i18n';
+import { useTranslation } from '@/hooks/useTranslation';
+import { AnimatedTooltip } from '@/components/ui/animated-tooltip';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+
+export default function ProjectPage({ params }: { params: { project: string } }) {
+  const { translatePerson } = useTranslatedPeople();
+  const { t } = useTranslation();
+
+  const project = hackathons.flatMap(h => h.projects).find(p => p.slug === params.project);
+  if (!project) return notFound();
+
+  const members = project.members.map((p, idx) => {
+    const tr = translatePerson(p);
+    return { id: idx, name: tr.name, designation: tr.role, image: tr.photo, link: tr.link };
+  });
+
+  return (
+    <div className="bg-Branco min-h-screen">
+      <Navbar />
+      <section className="py-20 px-4 md:px-28 flex flex-col gap-8">
+        <h1 className="text-3xl font-bold text-center text-AzulMeiaNoite font-poppins">
+          {project.name}
+        </h1>
+        <p className="text-center font-spaceGrotesk text-AzulMeiaNoite max-w-3xl mx-auto">
+          {t(project.descriptionKey)}
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {(project.images || []).map((img, idx) => (
+            <Image key={idx} src={`/${img}`} alt={project.name} width={600} height={400} className="rounded-lg object-cover" />
+          ))}
+        </div>
+        <div className="flex justify-center">
+          <AnimatedTooltip items={members} />
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/hackathons/page.tsx
+++ b/src/app/hackathons/page.tsx
@@ -1,0 +1,13 @@
+import Navbar from '@/components/NavBar';
+import Footer from '@/components/Footer';
+import HackathonsSection from '@/components/HackathonsSection';
+
+export default function HackathonsPage() {
+  return (
+    <div className="bg-Branco min-h-screen">
+      <Navbar />
+      <HackathonsSection />
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,11 +9,12 @@ export default function Footer() {
   const { t } = useTranslation();
 
   const sections = [
-    { name: t("navbar.about"), href: "#sobre" },
-    { name: t("navbar.testimonials"), href: "#depoimentos" },
-    { name: t("navbar.classes"), href: "#turmas" },
-    { name: t("navbar.who"), href: "#quem-somos" },
-    { name: t("navbar.faq"), href: "#faq" },
+    { name: t("navbar.about"), href: "/#sobre" },
+    { name: t("navbar.testimonials"), href: "/#depoimentos" },
+    { name: t("navbar.classes"), href: "/#turmas" },
+    { name: t("navbar.hackathons"), href: "/hackathons" },
+    { name: t("navbar.who"), href: "/#quem-somos" },
+    { name: t("navbar.faq"), href: "/#faq" },
   ];
 
   return (

--- a/src/components/HackathonsSection.tsx
+++ b/src/components/HackathonsSection.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import DynamicGrid from "./DynamicGrid";
+import { useTranslation } from "@/hooks/useTranslation";
+import { useTranslatedPeople } from "@/data/people-i18n";
+import { hackathons } from "@/data/hackathons";
+import { AnimatedTooltip } from "./ui/animated-tooltip";
+
+export default function HackathonsSection() {
+  const { t } = useTranslation();
+  const { translatePerson } = useTranslatedPeople();
+
+  return (
+    <section className="py-20 bg-Branco px-4 md:px-28 relative">
+      <DynamicGrid cellSize={50} className="opacity-5 z-0" numberOfCells={50} />
+      <div className="px-6">
+        <h2 className="text-1xl font-semibold text-center text-AzulCeu font-poppins mb-2 z-10">
+          {t("hackathons.title")}
+        </h2>
+        <h1 className="text-3xl font-bold text-center text-AzulMeiaNoite font-poppins mb-8 z-10">
+          {t("hackathons.subtitle")}
+        </h1>
+      </div>
+      <div className="flex flex-col gap-12">
+        {hackathons.map((hackathon, idx) => (
+          <div key={idx}>
+            <h2 className="text-2xl font-bold text-AzulMeiaNoite font-poppins mb-6 text-center">
+              {t(`hackathons.${hackathon.class.replace('.', '_')}`)}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+              {hackathon.projects.map((project, pIndex) => {
+                const members = project.members.map((p, index) => {
+                  const translated = translatePerson(p);
+                  return {
+                    id: index,
+                    name: translated.name,
+                    designation: translated.role,
+                    image: translated.photo,
+                    link: translated.link,
+                  };
+                });
+                return (
+                  <div
+                    key={pIndex}
+                    className="border-2 border-AzulMeiaNoite rounded-3xl p-6 bg-Branco/5"
+                  >
+                    <h3 className="text-xl font-bold font-poppins text-AzulMeiaNoite mb-2 text-center">
+                      {project.name}
+                    </h3>
+                    <p className="text-sm font-spaceGrotesk text-AzulMeiaNoite mb-4">
+                      {t(project.descriptionKey)}
+                    </p>
+                    <div className="flex justify-center">
+                      <AnimatedTooltip items={members} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/HackathonsSection.tsx
+++ b/src/components/HackathonsSection.tsx
@@ -3,10 +3,16 @@
 import DynamicGrid from "./DynamicGrid";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTranslatedPeople } from "@/data/people-i18n";
-import { hackathons } from "@/data/hackathons";
+import { hackathons, Hackathon } from "@/data/hackathons";
 import { AnimatedTooltip } from "./ui/animated-tooltip";
 
-export default function HackathonsSection() {
+export default function HackathonsSection({
+  hackathonsList = hackathons,
+  showMoreLink = true,
+}: {
+  hackathonsList?: Hackathon[];
+  showMoreLink?: boolean;
+}) {
   const { t } = useTranslation();
   const { translatePerson } = useTranslatedPeople();
 
@@ -22,7 +28,7 @@ export default function HackathonsSection() {
         </h1>
       </div>
       <div className="flex flex-col gap-12">
-        {hackathons.map((hackathon, idx) => (
+        {hackathonsList.map((hackathon, idx) => (
           <div key={idx}>
             <h2 className="text-2xl font-bold text-AzulMeiaNoite font-poppins mb-6 text-center">
               {t(`hackathons.${hackathon.class.replace('.', '_')}`)}
@@ -42,7 +48,7 @@ export default function HackathonsSection() {
                 return (
                   <div
                     key={pIndex}
-                    className="border-2 border-AzulMeiaNoite rounded-3xl p-6 bg-Branco/5"
+                    className="border-2 border-AzulMeiaNoite rounded-3xl p-6 bg-Branco/5 flex flex-col gap-4"
                   >
                     <h3 className="text-xl font-bold font-poppins text-AzulMeiaNoite mb-2 text-center">
                       {project.name}
@@ -53,6 +59,14 @@ export default function HackathonsSection() {
                     <div className="flex justify-center">
                       <AnimatedTooltip items={members} />
                     </div>
+                    {showMoreLink && (
+                      <a
+                        href={`/hackathons/${project.slug}`}
+                        className="text-AzulMeiaNoite underline text-center mt-auto"
+                      >
+                        {t('hackathons.moreDetails')}
+                      </a>
+                    )}
                   </div>
                 );
               })}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -32,11 +32,12 @@ export default function Navbar() {
           trilha
         </div>
         <div className="hidden md:flex space-x-12 text-AzulMeiaNoite">
-          <NavLink href="#sobre">{t("navbar.about")}</NavLink>
-          <NavLink href="#depoimentos">{t("navbar.testimonials")}</NavLink>
-          <NavLink href="#turmas">{t("navbar.classes")}</NavLink>
-          <NavLink href="#quem-somos">{t("navbar.who")}</NavLink>
-          <NavLink href="#faq">{t("navbar.faq")}</NavLink>
+          <NavLink href="/#sobre">{t("navbar.about")}</NavLink>
+          <NavLink href="/#depoimentos">{t("navbar.testimonials")}</NavLink>
+          <NavLink href="/#turmas">{t("navbar.classes")}</NavLink>
+          <NavLink href="/hackathons">{t("navbar.hackathons")}</NavLink>
+          <NavLink href="/#quem-somos">{t("navbar.who")}</NavLink>
+          <NavLink href="/#faq">{t("navbar.faq")}</NavLink>
         </div>
         <LanguageSwitcher />
       </div>

--- a/src/components/TurmaSection.tsx
+++ b/src/components/TurmaSection.tsx
@@ -3,12 +3,14 @@ import { useState } from "react";
 import { AnimatedTooltip } from "./ui/animated-tooltip";
 import { ChevronDown } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 import { useTranslation } from "@/hooks/useTranslation";
 
 const TurmaSection = ({
   title,
   organizers,
   students,
+  detailsLink,
 }: {
   title: string;
   organizers: {
@@ -25,6 +27,7 @@ const TurmaSection = ({
     link?: string;
     role: string;
   }[];
+  detailsLink?: string;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const { t } = useTranslation();
@@ -83,8 +86,8 @@ const TurmaSection = ({
               {t("turmaSection.students")}
             </h2>
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 px-4 md:px-4 lg:px-20">
-              {students.map((student, index) => (
-                <div key={index} className="flex flex-col items-center mb-6">
+          {students.map((student, index) => (
+            <div key={index} className="flex flex-col items-center mb-6">
                   <a
                     href={student.link}
                     target="_blank"
@@ -112,6 +115,13 @@ const TurmaSection = ({
                 </div>
               ))}
             </div>
+            {detailsLink && (
+              <div className="flex justify-center mt-4">
+                <Link href={detailsLink} className="underline">
+                  {t("turmaSection.moreDetails")}
+                </Link>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/Turmas.tsx
+++ b/src/components/Turmas.tsx
@@ -4,32 +4,38 @@ import TurmaSection from "./TurmaSection";
 import DynamicGrid from "./DynamicGrid";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTranslatedPeople } from "@/data/people-i18n";
+import { classes } from "@/data/classes";
 
 export default function Turmas() {
   const { t } = useTranslation();
-  const {
-    peopleOrganization20241: translatedOrg,
-    peopleStudents20241: translatedStudents,
-  } = useTranslatedPeople();
+  const { translatePerson } = useTranslatedPeople();
 
-  const transformedPeople20241 = translatedOrg.map((person, index) => ({
-    id: index,
-    name: person.name,
-    designation: person.role,
-    image: person.photo,
-    link: person.link,
-  }));
+  const transformOrganizers = (org: any[]) =>
+    org.map((person, index) => {
+      const translated = translatePerson(person);
+      return {
+        id: index,
+        name: translated.name,
+        designation: translated.role,
+        image: translated.photo,
+        link: translated.link,
+      };
+    });
 
-  const transformedPeopleStudents20241 = translatedStudents.map((person) => ({
-    name: person.name,
-    course: person.course || "",
-    photo: person.photo,
-    link: person.link,
-    role:
-      person.role.trim() === ""
-        ? t("people.roles.Ex Aluno Trilha")
-        : person.role,
-  }));
+  const transformStudents = (students: any[]) =>
+    students.map((person) => {
+      const translated = translatePerson(person);
+      return {
+        name: translated.name,
+        course: translated.course || "",
+        photo: translated.photo,
+        link: translated.link,
+        role:
+          translated.role.trim() === ""
+            ? t("people.roles.Ex Aluno Trilha")
+            : translated.role,
+      };
+    });
 
   return (
     <section
@@ -51,13 +57,20 @@ export default function Turmas() {
         </p>
       </div>
 
-      <div className="container mx-auto px-6 flex flex-col items-center justify-center z-10">
-        {/* Use the TurmaSection Component */}
-        <TurmaSection
-          title={t("turmas.firstClass")}
-          organizers={transformedPeople20241}
-          students={transformedPeopleStudents20241}
-        />
+      <div className="container mx-auto px-6 flex flex-col items-center justify-center z-10 gap-8">
+        {classes.map((cls) => {
+          const org = transformOrganizers(cls.organizers);
+          const stu = transformStudents(cls.students);
+          return (
+            <TurmaSection
+              key={cls.id}
+              title={t(`classPages.${cls.id.replace('.', '_')}.title`)}
+              organizers={org}
+              students={stu}
+              detailsLink={`/classes/${cls.id}`}
+            />
+          );
+        })}
       </div>
     </section>
   );

--- a/src/data/classes.ts
+++ b/src/data/classes.ts
@@ -1,0 +1,21 @@
+import { Person, peopleOrganization20241, peopleStudents20241 } from './people';
+
+export interface ClassInfo {
+  id: string;
+  titleKey: string;
+  descriptionKey: string;
+  images: string[];
+  organizers: Person[];
+  students: Person[];
+}
+
+export const classes: ClassInfo[] = [
+  {
+    id: '2024.1',
+    titleKey: 'classPages.2024_1.title',
+    descriptionKey: 'classPages.2024_1.description',
+    images: ['trilha2024.JPG', 'aulaTrilha.JPG', 'aulas.jpeg', 'palestra.JPG'],
+    organizers: peopleOrganization20241,
+    students: peopleStudents20241,
+  },
+];

--- a/src/data/hackathons.ts
+++ b/src/data/hackathons.ts
@@ -18,8 +18,10 @@ import {
 
 export interface HackathonProject {
   name: string;
+  slug: string;
   members: Person[];
   descriptionKey: string;
+  images: string[];
 }
 
 export interface Hackathon {
@@ -33,23 +35,31 @@ export const hackathons: Hackathon[] = [
     projects: [
       {
         name: 'ClarIAr',
+        slug: 'clariar',
         members: [Emyle, MiguelQueiroz, LuisAranha, JoseVitor],
         descriptionKey: 'hackathons.projects.ClarIAr.description',
+        images: ['trilha2024.JPG'],
       },
       {
         name: 'PerCurso',
+        slug: 'percurso',
         members: [NicolasKleiton, Bea, Luigi],
         descriptionKey: 'hackathons.projects.PerCurso.description',
+        images: ['trilha2024.JPG'],
       },
       {
         name: 'TrilhaSonora',
+        slug: 'trilhasonora',
         members: [Kruta, Clara, Artur],
         descriptionKey: 'hackathons.projects.TrilhaSonora.description',
+        images: ['trilha2024.JPG'],
       },
       {
         name: 'TARG',
+        slug: 'targ',
         members: [Marcus, VitorReis, DaviGurgel, RafaelTorres],
         descriptionKey: 'hackathons.projects.TARG.description',
+        images: ['trilha2024.JPG'],
       },
     ],
   },

--- a/src/data/hackathons.ts
+++ b/src/data/hackathons.ts
@@ -1,0 +1,56 @@
+import { Person } from './people';
+import {
+  Emyle,
+  MiguelQueiroz,
+  LuisAranha,
+  JoseVitor,
+  NicolasKleiton,
+  Bea,
+  Luigi,
+  Kruta,
+  Clara,
+  Artur,
+  Marcus,
+  VitorReis,
+  DaviGurgel,
+  RafaelTorres,
+} from './people';
+
+export interface HackathonProject {
+  name: string;
+  members: Person[];
+  descriptionKey: string;
+}
+
+export interface Hackathon {
+  class: string;
+  projects: HackathonProject[];
+}
+
+export const hackathons: Hackathon[] = [
+  {
+    class: '2024.1',
+    projects: [
+      {
+        name: 'ClarIAr',
+        members: [Emyle, MiguelQueiroz, LuisAranha, JoseVitor],
+        descriptionKey: 'hackathons.projects.ClarIAr.description',
+      },
+      {
+        name: 'PerCurso',
+        members: [NicolasKleiton, Bea, Luigi],
+        descriptionKey: 'hackathons.projects.PerCurso.description',
+      },
+      {
+        name: 'TrilhaSonora',
+        members: [Kruta, Clara, Artur],
+        descriptionKey: 'hackathons.projects.TrilhaSonora.description',
+      },
+      {
+        name: 'TARG',
+        members: [Marcus, VitorReis, DaviGurgel, RafaelTorres],
+        descriptionKey: 'hackathons.projects.TARG.description',
+      },
+    ],
+  },
+];

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -9,6 +9,7 @@
     "home": "Home",
     "about": "About",
     "classes": "Classes",
+    "hackathons": "Hackathons",
     "testimonials": "Testimonials",
     "who": "Who We Are",
     "faq": "FAQ"
@@ -178,5 +179,24 @@
     "Artur": "Trilha was essential to help me build a solid foundation in the basic concepts of programming and to follow a structured learning path in the various possible areas of the field, covering the main concepts necessary to enter real projects. During this journey, I developed practical and theoretical skills that were of paramount importance to my evolution. Having experiences with recognized professionals in the market and with former students was, for me, the most enriching part of the project. I am extremely happy to have had this unique opportunity!",
     "VitorReis": "Trilha was an incredible experience for me, in which I learned a lot in the field of programming, from the basics to more advanced concepts, and had my first experience in teamwork during the hackathon. In addition, I was able to meet incredible people, to whom I am extremely grateful for making my Fridays happier during Trilha.",
     "RafaelTorres": "Trilha was a transformative experience for me. The project not only helped me build a solid foundation, but also provided contact with very important subjects that I would hardly have known otherwise. Participating in Trilha at the beginning of the course was certainly one of the best decisions I made, I am very grateful to have participated."
+  },
+  "hackathons": {
+    "title": "Hackathons",
+    "subtitle": "Projects developed in our TRILHATHLON editions",
+    "2024_1": "TRILHATHLON 2024.1",
+    "projects": {
+      "ClarIAr": {
+        "description": "The grand winner, using Android's native resources and advanced language models to generate detailed, human-like descriptions of anything on screen."
+      },
+      "PerCurso": {
+        "description": "Collaborative platform that gathers past exams, useful links and study strategies for UFPB's Computer Science students. It is completely open source."
+      },
+      "TrilhaSonora": {
+        "description": "App that pairs reading with a custom soundtrack via Spotify, letting users pick public-domain books and control narration speed."
+      },
+      "TARG": {
+        "description": "Tool for investors featuring chart predictions, news sentiment analysis and historical data, built with AI technologies and web scraping."
+      }
+    }
   }
-} 
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -54,7 +54,8 @@
   },
   "turmaSection": {
     "organization": "Organization:",
-    "students": "Students:"
+    "students": "Students:",
+    "moreDetails": "More details"
   },
   "faq": {
     "title": "FAQ",
@@ -184,6 +185,7 @@
     "title": "Hackathons",
     "subtitle": "Projects developed in our TRILHATHLON editions",
     "2024_1": "TRILHATHLON 2024.1",
+    "moreDetails": "More details",
     "projects": {
       "ClarIAr": {
         "description": "The grand winner, using Android's native resources and advanced language models to generate detailed, human-like descriptions of anything on screen."
@@ -197,6 +199,12 @@
       "TARG": {
         "description": "Tool for investors featuring chart predictions, news sentiment analysis and historical data, built with AI technologies and web scraping."
       }
+    }
+  },
+  "classPages": {
+    "2024_1": {
+      "title": "Class 2024.1",
+      "description": "This is placeholder text describing the first class in more detail."
     }
   }
 }

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -54,7 +54,8 @@
   },
   "turmaSection": {
     "organization": "Organização:",
-    "students": "Alunos:"
+    "students": "Alunos:",
+    "moreDetails": "Mais detalhes"
   },
   "faq": {
     "title": "FAQ",
@@ -184,6 +185,7 @@
     "title": "Hackathons",
     "subtitle": "Projetos desenvolvidos nas nossas edições do TRILHATHLON",
     "2024_1": "TRILHATHLON 2024.1",
+    "moreDetails": "Mais detalhes",
     "projects": {
       "ClarIAr": {
         "description": "A grande vencedora do TRILHATHLON, inovando ao gerar descrições humanizadas e detalhadas de qualquer imagem na tela usando recursos nativos do Android e modelos de linguagem avançados."
@@ -197,6 +199,12 @@
       "TARG": {
         "description": "Ferramenta para investidores com previsões gráficas, análise de notícias e dados históricos, construída com tecnologias de IA e web scraping."
       }
+    }
+  },
+  "classPages": {
+    "2024_1": {
+      "title": "Turma 2024.1",
+      "description": "Texto fictício descrevendo mais detalhes sobre a primeira turma."
     }
   }
 }

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -9,6 +9,7 @@
     "home": "Início",
     "about": "Sobre",
     "classes": "Turmas",
+    "hackathons": "Hackathons",
     "testimonials": "Depoimentos",
     "who": "Quem Somos",
     "faq": "FAQ"
@@ -178,5 +179,24 @@
     "Artur": "O Trilha foi essencial para me ajudar a construir uma base sólida nos conceitos básicos de programação e a seguir um caminho estruturado de aprendizado nas diversas áreas possíveis do ramo, abrangendo os principais conceitos necessários para ingressar em projetos reais. Durante essa jornada, desenvolvi habilidades práticas e teóricas que foram de suma importância para a minha evolução. Ter experiências com profissionais reconhecidos no mercado e com ex-alunos foi, para mim, a parte mais engrandecedora do projeto. Estou extremamente feliz por ter tido essa oportunidade singular!",
     "VitorReis": "O Trilha foi uma experiência incrível pra mim, na qual aprendi muita coisa no ramo da programação, desde o básico até conceitos mais avançados, e tive minha primeira experiência em um trabalho em equipe no hackathon. Além disso, pude conhecer pessoas incríveis, as quais sou extremamente grato por terem feito minhas sextas-feiras mais felizes durante o Trilha.",
     "RafaelTorres": "O Trilha foi uma experiência transformadora para mim. O projeto não apenas me ajudou a construir uma base sólida, mas também proporcionou contato com assuntos muito importantes, que dificilmente eu conheceria de outra forma. Participar do Trilha no início do curso foi com certeza uma das melhores decisões que tomei, sou muito grato por ter participado."
+  },
+  "hackathons": {
+    "title": "Hackathons",
+    "subtitle": "Projetos desenvolvidos nas nossas edições do TRILHATHLON",
+    "2024_1": "TRILHATHLON 2024.1",
+    "projects": {
+      "ClarIAr": {
+        "description": "A grande vencedora do TRILHATHLON, inovando ao gerar descrições humanizadas e detalhadas de qualquer imagem na tela usando recursos nativos do Android e modelos de linguagem avançados."
+      },
+      "PerCurso": {
+        "description": "Plataforma colaborativa que reúne provas antigas, links úteis e estratégias de estudo para alunos de Ciência da Computação da UFPB, totalmente open source."
+      },
+      "TrilhaSonora": {
+        "description": "Aplicativo que integra leitura a uma trilha musical personalizada via Spotify, permitindo escolher livros de domínio público e ajustar a velocidade de narração."
+      },
+      "TARG": {
+        "description": "Ferramenta para investidores com previsões gráficas, análise de notícias e dados históricos, construída com tecnologias de IA e web scraping."
+      }
+    }
   }
-} 
+}


### PR DESCRIPTION
## Summary
- add Hackathons page and section component
- create dataset describing hackathon projects
- update navbar and footer links
- add texts for projects in translations

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844981d57008320a7a158a577738095