### PR TITLE
fix: navbar absolute links and project order correction

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -27,10 +27,10 @@ export default function NavBar() {
   }, []);
 
   const items = [
-    { id: 'sobre', label: t('nav.sobre'), url: '#sobre' },
-    { id: 'turmas', label: t('nav.turmas'), url: '#turmas' },
-    { id: 'projetos', label: t('nav.projetos'), url: '#projetos' },
-    { id: 'time', label: t('nav.time'), url: '#time' },
+    { id: 'sobre', label: t('nav.sobre'), url: '/#sobre' },
+    { id: 'turmas', label: t('nav.turmas'), url: '/#turmas' },
+    { id: 'projetos', label: t('nav.projetos'), url: '/#projetos' },
+    { id: 'time', label: t('nav.time'), url: '/#time' },
     { id: 'artigos', label: t('nav.artigos'), url: '/papers' },
   ];
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -59,8 +59,8 @@
     "title": "What comes out of a Trilha semester.",
     "lede": "Every semester ends with a themed hackathon. Teams build from scratch in a few days — below, some of the projects. (Links and details coming soon.)",
     "items": [
-      { "tag": "2024.1", "title": "Pixelmind", "desc": "AI-powered video editor: users upload a clip, describe the desired result, and the system automates the full edit.", "img": "/assets/projects/pixelmind.png", "pitch": "https://www.youtube.com/watch?v=DHXnobWWJjE" },
-      { "tag": "2024.2", "title": "ClarIAr", "desc": "Android accessibility app that uses LLMs to generate rich, natural descriptions of on-screen images, empowering visually impaired users.", "img": "/assets/projects/clariar.png", "pitch": "https://www.youtube.com/watch?v=0b4k1lVUtO4" },
+      { "tag": "2024.1", "title": "ClarIAr", "desc": "Android accessibility app that uses LLMs to generate rich, natural descriptions of on-screen images, empowering visually impaired users.", "img": "/assets/projects/clariar.png", "pitch": "https://www.youtube.com/watch?v=0b4k1lVUtO4" },
+      { "tag": "2024.2", "title": "Pixelmind", "desc": "AI-powered video editor: users upload a clip, describe the desired result, and the system automates the full edit.", "img": "/assets/projects/pixelmind.png", "pitch": "https://www.youtube.com/watch?v=DHXnobWWJjE" },
       { "tag": "2025.1", "title": "Praxis", "desc": "Hands-on learning platform for junior devs with track-specific challenges and AI feedback. Simulate, practice, evolve.", "img": "/assets/projects/praxis.png", "pitch": "https://www.youtube.com/watch?v=v5YYfLKEvV0" }
     ]
   },

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -59,8 +59,8 @@
     "title": "O que sai de um semestre no Trilha.",
     "lede": "Todo semestre fecha com um hackathon temático. As equipes constroem do zero em poucos dias — abaixo, alguns dos projetos. (Em breve com links e detalhes.)",
     "items": [
-      { "tag": "2024.1", "title": "Pixelmind", "desc": "Plataforma de edição de vídeo automatizada por IA: o usuário faz upload do vídeo, descreve o resultado desejado e a edição acontece sozinha.", "img": "/assets/projects/pixelmind.png", "pitch": "https://www.youtube.com/watch?v=DHXnobWWJjE" },
-      { "tag": "2024.2", "title": "ClarIAr", "desc": "App Android de acessibilidade que usa LLMs para descrever imagens da tela com naturalidade, dando mais autonomia a pessoas com deficiência visual.", "img": "/assets/projects/clariar.png", "pitch": "https://www.youtube.com/watch?v=0b4k1lVUtO4" },
+      { "tag": "2024.1", "title": "ClarIAr", "desc": "App Android de acessibilidade que usa LLMs para descrever imagens da tela com naturalidade, dando mais autonomia a pessoas com deficiência visual.", "img": "/assets/projects/clariar.png", "pitch": "https://www.youtube.com/watch?v=0b4k1lVUtO4" },
+      { "tag": "2024.2", "title": "Pixelmind", "desc": "Plataforma de edição de vídeo automatizada por IA: o usuário faz upload do vídeo, descreve o resultado desejado e a edição acontece sozinha.", "img": "/assets/projects/pixelmind.png", "pitch": "https://www.youtube.com/watch?v=DHXnobWWJjE" },
       { "tag": "2025.1", "title": "Praxis", "desc": "Plataforma de prática para devs iniciantes com desafios personalizados por trilha de carreira e feedback por IA. Simule, pratique, evolua.", "img": "/assets/projects/praxis.png", "pitch": "https://www.youtube.com/watch?v=v5YYfLKEvV0" }
     ]
   },


### PR DESCRIPTION
Summary

  - Navbar anchor links changed to absolute paths
  (/#sobre, /#turmas, etc.) so they navigate
  correctly from any route, not just the home page
  - ClarIAr and Pixelmind swapped: ClarIAr →
  2024.1, Pixelmind → 2024.2

  Test plan

  - From /papers (or any non-home route), click
  navbar links — should land on the correct home
  section
  - Projects section: ClarIAr shows 2024.1,
  Pixelmind shows 2024.2