### PR TITLE
fix(materiais): sidebar collapse + sticky header + cap TOC dots

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1001,7 +1001,11 @@ button { font-family: inherit; cursor: pointer; }
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 0 0 4px;
+  padding: 8px 0 6px;
+  position: sticky;
+  top: 0;
+  background: var(--cream);
+  z-index: 2;
 }
 .materiais-sidebar-collapse {
   background: transparent;

--- a/src/components/materiais/MaterialsSidebar.tsx
+++ b/src/components/materiais/MaterialsSidebar.tsx
@@ -9,9 +9,12 @@ interface MaterialsSidebarProps {
   areas: AreaStructure[];
 }
 
+const COLLAPSED_KEY = "materiais-sidebar-collapsed";
+
 export default function MaterialsSidebar({ areas }: MaterialsSidebarProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
   const pathname = usePathname();
 
   useEffect(() => {
@@ -22,24 +25,52 @@ export default function MaterialsSidebar({ areas }: MaterialsSidebarProps) {
     setMobileOpen(false);
   }, [pathname]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(COLLAPSED_KEY);
+    if (stored === "true") setCollapsed(true);
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.documentElement.dataset.materiaisCollapsed = String(collapsed);
+    window.localStorage.setItem(COLLAPSED_KEY, String(collapsed));
+    return () => {
+      delete document.documentElement.dataset.materiaisCollapsed;
+    };
+  }, [collapsed]);
+
   const toggle = (slug: string) =>
     setExpanded((prev) => {
       const n = new Set(prev);
-      n.has(slug) ? n.delete(slug) : n.add(slug);
+      if (n.has(slug)) n.delete(slug);
+      else n.add(slug);
       return n;
     });
 
   const isActive = (area: string, slug: string) => pathname === `/materiais/${area}/${slug}`;
   const isIndex = pathname === "/materiais";
 
-  const Content = () => (
+  const Content = ({ showCollapse = false }: { showCollapse?: boolean }) => (
     <div className="materiais-sidebar-inner">
-      <Link
-        href="/materiais"
-        className={`materiais-sidebar-home ${isIndex ? "is-active" : ""}`}
-      >
-        Início
-      </Link>
+      <div className="materiais-sidebar-header">
+        <Link
+          href="/materiais"
+          className={`materiais-sidebar-home ${isIndex ? "is-active" : ""}`}
+        >
+          Início
+        </Link>
+        {showCollapse && (
+          <button
+            onClick={() => setCollapsed(true)}
+            className="materiais-sidebar-collapse"
+            aria-label="Recolher menu"
+            title="Recolher menu"
+          >
+            «
+          </button>
+        )}
+      </div>
       <div className="materiais-sidebar-rule" />
       <nav className="materiais-sidebar-nav">
         {areas.map((area) => {
@@ -93,6 +124,18 @@ export default function MaterialsSidebar({ areas }: MaterialsSidebarProps) {
         Materiais
       </button>
 
+      {collapsed && (
+        <button
+          onClick={() => setCollapsed(false)}
+          className="materiais-sidebar-expand"
+          aria-label="Abrir menu de materiais"
+          title="Abrir menu"
+        >
+          <span className="materiais-sidebar-expand-icon" aria-hidden="true">»</span>
+          <span>Materiais</span>
+        </button>
+      )}
+
       {mobileOpen && (
         <div className="materiais-sidebar-overlay" onClick={() => setMobileOpen(false)} />
       )}
@@ -110,7 +153,7 @@ export default function MaterialsSidebar({ areas }: MaterialsSidebarProps) {
 
       <aside className="materiais-sidebar-desktop">
         <div className="materiais-sidebar-sticky">
-          <Content />
+          <Content showCollapse />
         </div>
       </aside>
     </>

--- a/src/components/materiais/TableOfContents.tsx
+++ b/src/components/materiais/TableOfContents.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 interface Heading {
   id: string;
@@ -17,7 +17,6 @@ export default function TableOfContents({ headings }: TableOfContentsProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Define o primeiro heading como ativo inicialmente
   useEffect(() => {
     if (headings && headings.length > 0 && !activeId) {
       setActiveId(headings[0].id);
@@ -29,25 +28,20 @@ export default function TableOfContents({ headings }: TableOfContentsProps) {
 
     const observer = new IntersectionObserver(
       (entries) => {
-        // Filtra apenas as entradas visíveis
-        const visibleEntries = entries.filter(entry => entry.isIntersecting);
-        
+        const visibleEntries = entries.filter((entry) => entry.isIntersecting);
         if (visibleEntries.length > 0) {
-          // Pega o primeiro heading visível na viewport
-          const topEntry = visibleEntries.reduce((prev, current) => {
-            return prev.boundingClientRect.top < current.boundingClientRect.top ? prev : current;
-          });
-          
+          const topEntry = visibleEntries.reduce((prev, current) =>
+            prev.boundingClientRect.top < current.boundingClientRect.top ? prev : current
+          );
           setActiveId(topEntry.target.id);
         }
       },
-      { 
+      {
         rootMargin: "-100px 0px -66% 0px",
-        threshold: [0, 0.25, 0.5, 0.75, 1]
+        threshold: [0, 0.25, 0.5, 0.75, 1],
       }
     );
 
-    // Adiciona um pequeno delay para garantir que os elementos estão renderizados
     const timeoutId = setTimeout(() => {
       headings.forEach((heading) => {
         const element = document.getElementById(heading.id);
@@ -78,31 +72,92 @@ export default function TableOfContents({ headings }: TableOfContentsProps) {
     }
   };
 
-  if (!headings || headings.length === 0) return null;
+  const minLevel = useMemo(
+    () => (headings.length > 0 ? Math.min(...headings.map((h) => h.level)) : 0),
+    [headings]
+  );
 
-  const minLevel = Math.min(...headings.map((h) => h.level));
+  // Apenas os headings de nível principal (ex.: só H2 quando há H2/H3/H4)
+  const mainHeadings = useMemo(
+    () => headings.filter((h) => h.level === minLevel),
+    [headings, minLevel]
+  );
+
+  // Cap visual em N tracinhos — páginas com 30+ headings viravam paredão
+  const MAX_DOTS = 12;
+  const dotHeadings = useMemo(() => {
+    if (mainHeadings.length <= MAX_DOTS) return mainHeadings;
+    const step = (mainHeadings.length - 1) / (MAX_DOTS - 1);
+    return Array.from({ length: MAX_DOTS }, (_, i) =>
+      mainHeadings[Math.round(i * step)]
+    );
+  }, [mainHeadings]);
+
+  // O tracinho ativo é o principal mais próximo (anterior ou igual) ao heading atual
+  const activeMainId = useMemo(() => {
+    if (!activeId) return "";
+    const idx = headings.findIndex((h) => h.id === activeId);
+    if (idx < 0) return "";
+    for (let i = idx; i >= 0; i--) {
+      if (headings[i].level === minLevel) return headings[i].id;
+    }
+    return "";
+  }, [activeId, headings, minLevel]);
+
+  // Quando há sampling, mapeia activeMain → tracinho exibido mais próximo
+  const activeDotId = useMemo(() => {
+    if (!activeMainId) return "";
+    if (dotHeadings.length === mainHeadings.length) return activeMainId;
+    const activeIdx = mainHeadings.findIndex((h) => h.id === activeMainId);
+    if (activeIdx < 0) return "";
+    let bestId = dotHeadings[0]?.id ?? "";
+    let bestDist = Infinity;
+    for (const dh of dotHeadings) {
+      const di = mainHeadings.findIndex((m) => m.id === dh.id);
+      const dist = Math.abs(di - activeIdx);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestId = dh.id;
+      }
+    }
+    return bestId;
+  }, [activeMainId, dotHeadings, mainHeadings]);
+
+  if (!headings || headings.length === 0) return null;
 
   return (
     <div
-      className="fixed top-1/2 -translate-y-1/2 right-4 hidden xl:flex z-50"
+      className="fixed top-1/2 -translate-y-1/2 right-4 hidden xl:flex z-40"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      {/* Painel expandido */}
+      {/* Painel expandido (hover) */}
       <div
-        className="overflow-hidden bg-white dark:bg-slate-900 rounded-xl shadow-xl border border-gray-200 dark:border-slate-700"
+        className="overflow-hidden"
         style={{
           width: isExpanded ? 280 : 0,
           opacity: isExpanded ? 1 : 0,
           marginRight: isExpanded ? 12 : 0,
           transition: "all 300ms cubic-bezier(0.4, 0, 0.2, 1)",
+          background: "var(--cream)",
+          border: "1px solid var(--rule)",
+          borderRadius: "var(--radius-m)",
+          boxShadow: "0 12px 32px -16px rgba(26,24,21,0.18)",
         }}
       >
         <div
-          className="overflow-y-auto p-4"
+          className="overflow-y-auto no-scrollbar p-4"
           style={{ maxHeight: "60vh", width: 280 }}
         >
-          <p className="text-xs font-bold text-gray-500 dark:text-gray-400 mb-3 uppercase tracking-wide">
+          <p
+            className="mb-3 uppercase"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              letterSpacing: "0.08em",
+              color: "var(--ink-muted)",
+            }}
+          >
             Nesta página
           </p>
           <nav>
@@ -115,15 +170,15 @@ export default function TableOfContents({ headings }: TableOfContentsProps) {
                   <li key={heading.id}>
                     <button
                       onClick={() => scrollToHeading(heading.id)}
-                      className={`
-                        w-full text-left py-1.5 px-3 rounded-lg text-sm
-                        transition-colors duration-150
-                        ${isActive
-                          ? "bg-AzulEletrico/10 text-AzulEletrico dark:bg-AzulCeu/20 dark:text-AzulCeu font-medium"
-                          : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-slate-800 hover:text-gray-900 dark:hover:text-gray-200"
-                        }
-                      `}
-                      style={{ paddingLeft: `${12 + indent * 12}px` }}
+                      className="w-full text-left py-1.5 px-3 rounded-md transition-colors duration-150"
+                      style={{
+                        paddingLeft: `${12 + indent * 12}px`,
+                        fontSize: 14,
+                        lineHeight: 1.4,
+                        background: isActive ? "var(--mint-soft)" : "transparent",
+                        color: isActive ? "var(--ink)" : "var(--ink-soft)",
+                        fontWeight: isActive ? 500 : 400,
+                      }}
                     >
                       {heading.text}
                     </button>
@@ -135,22 +190,30 @@ export default function TableOfContents({ headings }: TableOfContentsProps) {
         </div>
       </div>
 
-      {/* Indicadores minimalistas estilo Notion */}
-      <div className="flex flex-col items-end gap-[6px] py-1 max-h-[60vh] overflow-y-auto">
-        {headings.map((heading) => {
-          const isActive = activeId === heading.id;
+      {/* Indicadores minimalistas — apenas pontos principais (max 12) */}
+      <div className="flex flex-col items-end gap-[8px] py-1 max-h-[60vh] overflow-y-auto no-scrollbar">
+        {dotHeadings.map((heading) => {
+          const isActive = activeDotId === heading.id;
           return (
             <button
               key={heading.id}
               onClick={() => scrollToHeading(heading.id)}
               aria-label={heading.text}
-              className={`
-                h-[2px] rounded-[1px] transition-all duration-200 flex-shrink-0
-                ${isActive
-                  ? "w-5 bg-gray-800 dark:bg-gray-200"
-                  : "w-3 bg-gray-300 dark:bg-gray-600 hover:bg-gray-400 dark:hover:bg-gray-500"
+              className="h-[2px] rounded-[1px] transition-all duration-200 flex-shrink-0"
+              style={{
+                width: isActive ? 24 : 14,
+                background: isActive ? "var(--ink)" : "var(--rule)",
+              }}
+              onMouseEnter={(e) => {
+                if (!isActive) {
+                  (e.currentTarget as HTMLButtonElement).style.background = "var(--ink-muted)";
                 }
-              `}
+              }}
+              onMouseLeave={(e) => {
+                if (!isActive) {
+                  (e.currentTarget as HTMLButtonElement).style.background = "var(--rule)";
+                }
+              }}
             />
           );
         })}


### PR DESCRIPTION
## Summary

Follow-up to #29. The CSS for the collapse/expand UI shipped to main, but a few pieces were missing or off:

- **Sidebar collapse didn't work on `main`**: the CSS referenced `.materiais-sidebar-header`, `.materiais-sidebar-collapse`, `.materiais-sidebar-expand`, but `MaterialsSidebar.tsx` wasn't rendering them. This PR wires up the actual collapse logic (state + `localStorage` persist + data attribute on `<html>` for the global CSS hook).
- **Collapse button vanished on scroll**: in long material areas the sidebar list scrolled past the « collapse button. Made `.materiais-sidebar-header` `position: sticky` inside the scroll container so it stays pinned.
- **TOC dot wall**: pages like `10-poo` have 30+ H1s, producing a vertical wall of dashes on the right edge. Capped to max 12 dots via even sampling, with the active dot mapped to the nearest sampled heading.

## Test plan
- [ ] `/materiais/<area>/<slug>` desktop: click « in the sidebar → animation smooth, sidebar slides out, » expand chip fades in
- [ ] Click » → sidebar slides back in, animation smooth
- [ ] Scroll sidebar way down on a long area → « collapse button stays pinned at top
- [ ] Open `/materiais/1-introducao-ao-python/10-poo` → right-side dot strip shows ≤12 dots, active dot tracks scroll
- [ ] Open a short material → all dots visible (no sampling)
- [ ] Refresh after collapse → state persists via localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)