### PR TITLE
fix(materiais): unbreak image rendering (avif, stale slugs, wrong paths)

### DIFF
--- a/src/app/api/materiais-assets/[...path]/route.ts
+++ b/src/app/api/materiais-assets/[...path]/route.ts
@@ -39,7 +39,14 @@ export async function GET(
       ".jpeg": "image/jpeg",
       ".gif": "image/gif",
       ".webp": "image/webp",
+      ".avif": "image/avif",
       ".svg": "image/svg+xml",
+      ".ico": "image/x-icon",
+      ".mp4": "video/mp4",
+      ".webm": "video/webm",
+      ".mov": "video/quicktime",
+      ".m4v": "video/mp4",
+      ".ogg": "video/ogg",
       ".pdf": "application/pdf",
     };
 

--- a/src/content/materiais/1-introducao-ao-python/10-poo/index.md
+++ b/src/content/materiais/1-introducao-ao-python/10-poo/index.md
@@ -100,7 +100,7 @@ Inicialmente pode não ser claro como POO ajuda, parecendo talvez até como uma 
 
 Mas ainda advogando sobre a utilidade de POO, a imagem abaixo cria mais um contexto:
 
-![1767191523867](/api/materiais-assets/1-introducao-ao-python/9-poo/assets/1767191523867.png)
+![1767191523867](/api/materiais-assets/1-introducao-ao-python/10-poo/assets/1767191523867.png)
 
 Sabemos que todo carro possui suas características únicas e ao mesmo tempo ainda seguem padrões presentes na maioria dos carros. Com uma classe, algo genérico, é possível organizar os padrões que devem ser seguidos. Além de que facilita o processo de criar algo que possuem as mesmas características.
 

--- a/src/content/materiais/1-introducao-ao-python/11-appendix/index.md
+++ b/src/content/materiais/1-introducao-ao-python/11-appendix/index.md
@@ -57,7 +57,7 @@ python -m venv .venv
 
 Ao rodar o comando, você verá algo parecido com isso:
 
-![Pasta .venv](/api/materiais-assets/1-introducao-ao-python/10-appendix/assets/venv.png)
+![Pasta .venv](/api/materiais-assets/1-introducao-ao-python/11-appendix/assets/venv.png)
 
 ### Ativando o ambiente virtual
 
@@ -200,7 +200,7 @@ uv init
 
 O comando `uv init` cria automaticamente toda a estrutura inicial do projeto. Veja como fica:
 
-![estrutura gerada pelo uv init](/api/materiais-assets/1-introducao-ao-python/10-appendix/assets/uv_init.png)
+![estrutura gerada pelo uv init](/api/materiais-assets/1-introducao-ao-python/11-appendix/assets/uv_init.png)
 
 Vamos entender cada arquivo criado:
 

--- a/src/content/materiais/1-introducao-ao-python/12-exemplo-pratico/index.md
+++ b/src/content/materiais/1-introducao-ao-python/12-exemplo-pratico/index.md
@@ -66,7 +66,7 @@ Vamos mapear nosso problema:
 
 ### Como elas se relacionam?
 
-![Estrutura do Projeto](/api/materiais-assets/1-introducao-ao-python/11-exemplo-pratico/assets/estrutura.png)
+![Estrutura do Projeto](/api/materiais-assets/1-introducao-ao-python/12-exemplo-pratico/assets/estrutura.png)
 
 Perceba que:
 - **Metric** é abstrata: não faz sentido criar uma "métrica genérica", só métricas específicas

--- a/src/content/materiais/1-introducao-ao-python/9-frameworks-e-bibliotecas/index.md
+++ b/src/content/materiais/1-introducao-ao-python/9-frameworks-e-bibliotecas/index.md
@@ -179,7 +179,7 @@ Um pacote é uma **pasta** que contém vários módulos relacionados. Para criar
 3. Colocar seus módulos dentro da pasta
 
 **Estrutura de exemplo:**
-![Estrutura de exemplo](/api/materiais-assets/1-introducao-ao-python/8-frameworks-e-bibliotecas/assets/estrutura_projeto.png)
+![Estrutura de exemplo](/api/materiais-assets/1-introducao-ao-python/9-frameworks-e-bibliotecas/assets/estrutura_projeto.png)
 
 ```python
 # Arquivo: matematica/basica.py
@@ -295,10 +295,10 @@ Quando uma equipe usa o mesmo framework, é como se todos falassem a mesma líng
 ## Frameworks Populares
 
 ### Frameworks Python
-![Principais Frameworks Python](/api/materiais-assets/1-introducao-ao-python/8-frameworks-e-bibliotecas/assets/frameworks_python.png)
+![Principais Frameworks Python](/api/materiais-assets/1-introducao-ao-python/9-frameworks-e-bibliotecas/assets/frameworks_python.png)
 
 ### Frameworks JavaScript
-![Principais Frameworks JavaScript](/api/materiais-assets/1-introducao-ao-python/8-frameworks-e-bibliotecas/assets/frameworks_js.png)
+![Principais Frameworks JavaScript](/api/materiais-assets/1-introducao-ao-python/9-frameworks-e-bibliotecas/assets/frameworks_js.png)
 
 ## Exemplos práticos de Frameworks em Python
 
@@ -330,11 +330,11 @@ python main.py
 
 Você verá algo assim:
 
-![Flask executando no terminal](/api/materiais-assets/1-introducao-ao-python/8-frameworks-e-bibliotecas/assets/flask_terminal.png)
+![Flask executando no terminal](/api/materiais-assets/1-introducao-ao-python/9-frameworks-e-bibliotecas/assets/flask_terminal.png)
 
 Ao acessar o link **http://127.0.0.1:5000** no browser, você verá a página a seguir:
 
-![Página web Flask](/api/materiais-assets/1-introducao-ao-python/8-frameworks-e-bibliotecas/assets/flask_web.png)
+![Página web Flask](/api/materiais-assets/1-introducao-ao-python/9-frameworks-e-bibliotecas/assets/flask_web.png)
 
 > Para matar o processo, basta dar um CTRL+C no terminal.
 

--- a/src/content/materiais/2-estruturas-de-dados/1-introducao/index.md
+++ b/src/content/materiais/2-estruturas-de-dados/1-introducao/index.md
@@ -86,7 +86,7 @@ Já sabemos que podemos armazenar informações por meio da **declaração de va
   </div>
 
   <div>
-    <img src="images/memoria.png" width="300">
+    <img src="/api/materiais-assets/2-estruturas-de-dados/1-introducao/assets/memoria.png" width="300">
   </div>
 
 </div>

--- a/src/content/materiais/2-estruturas-de-dados/2-arrays/index.md
+++ b/src/content/materiais/2-estruturas-de-dados/2-arrays/index.md
@@ -24,7 +24,7 @@ Então surge a pergunta:
 
 Sim, com arrays. Um **array** é uma **variável estruturada** que armazena vários valores do **mesmo tipo** de forma **contínua na memória** sob **um único nome** com acesso por **índice**. Isso significa que em vez de variáveis separadas, usamos apenas uma estrutura:
 
-<img src="images/array.png" width="70%">
+<img src="/api/materiais-assets/2-estruturas-de-dados/2-arrays/assets/array.png" width="70%">
 
 Cada posição do array possui um **índice**, que indica a posição de um elemento. Note que na imagem, os índices do array começam em 0, porque é assim na maioria das linguagens de Programação, como Python, C e Java. Além disso, Para acessar os valores, usamos a notação com colchetes `[]`:
 
@@ -634,7 +634,7 @@ Vocês estão espalhados, mas **conectados**. Se seguirmos as pistas, encontramo
 
 > **Moral da História:** Arrays exigem memória vizinha (contígua). Linked Lists aceitam memória espalhada (fragmentada).
 
-<img src="images/linked_list.png" width="500">
+<img src="/api/materiais-assets/2-estruturas-de-dados/2-arrays/assets/linked_list.png" width="500">
 
 *Em azul está uma lista convencional e em verde uma linked list.*
 
@@ -795,7 +795,7 @@ Cada nó agora tem dois braços: um para segurar o da frente (next) e um para se
 - **Vantagem:** Permite ir e vir (botão Voltar/Avançar do navegador).
 - **Custo:** Ocupa mais memória (precisa guardar 2 endereços por item).
 
-<img src="images/doubly_linked.png" width="500">
+<img src="/api/materiais-assets/2-estruturas-de-dados/2-arrays/assets/doubly_linked.png" width="500">
 
 # 2.14. O Jeito Pythonico (`collections.deque`)
 

--- a/src/content/materiais/2-estruturas-de-dados/3-tabelas-de-dispersao/index.md
+++ b/src/content/materiais/2-estruturas-de-dados/3-tabelas-de-dispersao/index.md
@@ -25,7 +25,7 @@ O objetivo da função de dispersão é **transformar uma chave** (que pode ser 
 
 > **Exemplo:** O sistema tem um dado referente ao funcionário que funciona como a chave (ex: ID 3809). A partir disso, a função de dispersão calcula qual seria o índice correspondente.
 
-<img src="images/hash.png" width=500>
+<img src="/api/materiais-assets/2-estruturas-de-dados/3-tabelas-de-dispersao/assets/hash.png" width=500>
 
 ## Mas que Tipo de Função é Essa?
 

--- a/src/content/materiais/2-estruturas-de-dados/4-conjuntos/index.md
+++ b/src/content/materiais/2-estruturas-de-dados/4-conjuntos/index.md
@@ -151,7 +151,7 @@ Analisando os resultados das operações acima:
 3. **Diferença (`-`):** A variável `diferenca` conterá `{1}`. Note que esta operação não é comutativa; ela remove de `a` tudo que também existe em `b`.
 4. **Diferença Simétrica (`^`):** A variável `dif_simetrica` resultará em `{1, 4}`. Este é o "Ou Exclusivo" (XOR), mantendo apenas o que é exclusivo de cada lado e descartando o que é comum.
 
-<img src="images/diagrama_venn.png" width="500">
+<img src="/api/materiais-assets/2-estruturas-de-dados/4-conjuntos/assets/diagrama_venn.png" width="500">
 
 ## **Exercício de Fixação**
 

--- a/src/content/materiais/2-estruturas-de-dados/6-pilha-e-filas/index.md
+++ b/src/content/materiais/2-estruturas-de-dados/6-pilha-e-filas/index.md
@@ -9,7 +9,7 @@ order: 6
 
 Uma Pilha, como estrutura de dados, é uma sequência lógica onde os elementos são inseridos e removidos apenas por uma das extremidades, denominada topo. Esse fluxo de manipulação é chamado de LIFO (Last In, First Out — o último a entrar é o primeiro a sair). Para exemplificar seu funcionamento, imagine uma pilha de livros organizada para estudo. Sempre que você adquire um novo material, você o coloca no topo para que ele seja o próximo a ser lido. A remoção segue a mesma lógica: você retira primeiro o que está em cima para acessar o conteúdo de forma ordenada. Da mesma forma, em uma pilha de dados, o acesso ocorre sempre pelo topo, garantindo que o elemento mais recente seja sempre o primeiro a ser processado.
 
-<img src="images/stack.png" width=500>
+<img src="/api/materiais-assets/2-estruturas-de-dados/6-pilha-e-filas/assets/stack.png" width=500>
 
 ## Operações principais
 
@@ -42,7 +42,7 @@ Assim como as filas que existem no nosso cotidiano (no supermercado, por exemplo
 
 Um exemplo comum de uso dessa estrutura é uma fila de músicas, como em aplicativos de streaming (Spotify, por exemplo), em que as músicas são reproduzidas na mesma ordem em que foram adicionadas à fila.
 
-<img src="images/queue.png" width=500>
+<img src="/api/materiais-assets/2-estruturas-de-dados/6-pilha-e-filas/assets/queue.png" width=500>
 
 ## Operações principais
 

--- a/src/content/materiais/4-backend/9-infraestrutura-de-apis/index.md
+++ b/src/content/materiais/4-backend/9-infraestrutura-de-apis/index.md
@@ -251,7 +251,6 @@ Com esse arquivo aplicado no Kubernetes, o desenvolvedor Python não precisa pro
 
 Como colocar código novo em produção sem derrubar o sistema ou afetar todos os usuários com um bug?
 
-![image_grafico_blue_green](/api/materiais-assets/backend/infraestrutura-de-apis/assets/)
 ![image_grafico_canary](/api/materiais-assets/4-backend/9-infraestrutura-de-apis/assets/canary.png)
 *Sugestão de imagem: Gráficos mostrando o tráfego mudando. Blue/Green (Troca súbita de 100%). Canary (Gradual: 1% -> 10% -> 100%).*
 


### PR DESCRIPTION
## Summary

Audited every artifact reference across all 6 areas of `/materiais` via 5 parallel agents. Found three categories of broken images and fixed them:

### 1. AVIF served as octet-stream (3-dados)
The assets API at `src/app/api/materiais-assets/[...path]/route.ts` had a content-type map missing `.avif`. Added avif, plus mp4/webm/mov/ico/m4v/ogg for future-proofing.

Broken refs that this fixes:
- `3-dados/1-tipos-de-dados/index.md` (3 .avif diagrams)
- `3-dados/6-ciencia-de-dados/index.md` (mse.avif)

### 2. Stale slug paths (1-introducao-ao-python)
Folders were renumbered but the API URLs inside the markdown weren't updated → 10 images 404'd. Updated paths:
- `10-appendix` → `11-appendix`
- `9-poo` → `10-poo`
- `11-exemplo-pratico` → `12-exemplo-pratico`
- `8-frameworks-e-bibliotecas` → `9-frameworks-e-bibliotecas`

### 3. Wrong path convention (2-estruturas-de-dados)
All 8 raw `<img src="images/foo.png">` tags resolved against the page route → 404. Files actually live in `assets/`. Rewrote to use the API route.

### 4. Orphan ref (4-backend)
Removed `9-infraestrutura-de-apis/index.md:254` — broken markdown image with malformed area prefix pointing to a non-existent blue/green asset. The neighboring canary image works fine.

## Areas confirmed clean (no fixes needed)
- `4-backend` (after the orphan removal)
- `5-banco-de-dados` (all png/jpg/webp + 4 standard YouTube watch links)
- `6-frontend` (52 image refs, all standard)

## Out of scope (noted for follow-up)
- `1-introducao-ao-python/2-variaveis-e-fundamentos/index.md:63` has a YouTube **playlist** URL — the renderer's regex only embeds `watch?v=` or `youtu.be/`, so it renders as a plain link. Not a regression; leave for now.

## Test plan
- [ ] `/materiais/3-dados/1-tipos-de-dados` → 3 avif images render
- [ ] `/materiais/1-introducao-ao-python/11-appendix` → venv.png + uv_init.png render
- [ ] `/materiais/1-introducao-ao-python/10-poo` → 1767191523867.png renders
- [ ] `/materiais/1-introducao-ao-python/12-exemplo-pratico` → estrutura.png renders
- [ ] `/materiais/1-introducao-ao-python/9-frameworks-e-bibliotecas` → 5 images render
- [ ] `/materiais/2-estruturas-de-dados/2-arrays` → array/linked_list/doubly_linked all render
- [ ] `/materiais/4-backend/9-infraestrutura-de-apis` → no broken image, canary still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)