### PR TITLE
fix(materiais): tighten top padding above content and sidebar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -867,7 +867,7 @@ button { font-family: inherit; cursor: pointer; }
   transition: grid-template-columns .35s cubic-bezier(.4, 0, .2, 1), gap .35s cubic-bezier(.4, 0, .2, 1);
 }
 .materiais-content { min-width: 0; }
-.materiais-content .section { padding-left: 0; padding-right: 0; }
+.materiais-content .section { padding-left: 0; padding-right: 0; padding-top: clamp(32px, 4vw, 56px); }
 .materiais-content .container { max-width: none; margin: 0; }
 @media (max-width: 1024px) {
   .materiais-shell { grid-template-columns: 1fr; }
@@ -875,7 +875,7 @@ button { font-family: inherit; cursor: pointer; }
 }
 
 .materiais-sidebar-desktop {
-  padding-top: var(--section-y);
+  padding-top: clamp(32px, 4vw, 56px);
   overflow: hidden;
   transition: opacity .25s ease, transform .35s cubic-bezier(.4, 0, .2, 1);
   will-change: opacity, transform;


### PR DESCRIPTION
## Summary
- Reduces the empty space between the nav and the first materiais section from ~80–160px (`var(--section-y)`) down to `clamp(32px, 4vw, 56px)`.
- Mirrors the same value on `.materiais-sidebar-desktop` so the sidebar and content stay aligned.

## Test plan
- [ ] Open `/materiais` and confirm "MATERIAIS" eyebrow + heading sit closer to the nav with less dead space.
- [ ] Scroll: sidebar "INÍCIO" still aligns with the eyebrow.
- [ ] Resize down to <1024px (sidebar hidden) — content top spacing still looks balanced.
- [ ] Visit a nested material page (`/materiais/<area>/<slug>`) and confirm the new padding works there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)