### PR TITLE
feat(papers): track paper card clicks on /papers with Posthog

### DIFF
--- a/POSTHOG_TRACKING.md
+++ b/POSTHOG_TRACKING.md
@@ -94,6 +94,18 @@ This document outlines all the PostHog tracking events implemented on the main p
   - `page`: "home"
 - **Trigger**: When a section becomes visible in viewport
 
+### 13. Paper Card Click
+- **Event**: `paper_card_clicked`
+- **Properties**:
+  - `paperSlug`: string (e.g. "fullstack-do-zero")
+  - `paperTitle`: string
+  - `paperTag`: string (e.g. "Fullstack", "Machine Learning")
+  - `paperLang`: "pt" | "en"
+  - `paperAuthor`: string
+  - `position`: number (0-based index in the grid at click time)
+  - `page`: "papers"
+- **Trigger**: When user clicks a paper card on `/papers`
+
 ## Implementation Details
 
 ### Files Modified:
@@ -105,6 +117,7 @@ This document outlines all the PostHog tracking events implemented on the main p
 6. `src/components/TurmaSection.tsx` - Turma section and profile tracking
 7. `src/components/ScrollTracker.tsx` - Scroll depth and section visibility
 8. `src/app/page.tsx` - Added ScrollTracker component
+9. `src/app/papers/page.tsx` - Paper card click tracking
 
 ### Key Features:
 - **Automatic page view tracking** (PostHog default)

--- a/src/app/papers/page.tsx
+++ b/src/app/papers/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { usePostHogTracking } from '@/hooks/usePostHogTracking';
 import { useTranslation } from '@/hooks/useTranslation';
 
 type Paper = { slug: string; tag: string; title: string; desc: string; lang: string; author: string };
 
 export default function PapersPage() {
   const { t } = useTranslation();
+  const { trackPaperClick } = usePostHogTracking();
   const papers = t<Paper[]>('papers.items');
 
   return (
@@ -18,13 +20,14 @@ export default function PapersPage() {
         </header>
 
         <div className="papers-grid">
-          {papers.map((p) => (
+          {papers.map((p, index) => (
             <a
               key={p.slug}
               href={`/papers/${p.slug}.html`}
               target="_blank"
               rel="noreferrer"
               className="paper-card"
+              onClick={() => trackPaperClick(p, index)}
             >
               <div className="paper-card-body">
                 <div className="paper-card-top">

--- a/src/hooks/usePostHogTracking.ts
+++ b/src/hooks/usePostHogTracking.ts
@@ -156,6 +156,30 @@ export const usePostHogTracking = () => {
     }
   }, [posthog, isDebug]);
 
+  // Track paper card clicks on /papers
+  const trackPaperClick = useCallback(
+    (
+      paper: { slug: string; title: string; tag: string; lang: string; author: string },
+      position: number
+    ) => {
+      const eventData = {
+        paperSlug: paper.slug,
+        paperTitle: paper.title,
+        paperTag: paper.tag,
+        paperLang: paper.lang,
+        paperAuthor: paper.author,
+        position,
+        page: "papers",
+        version: "v2",
+      };
+      posthog?.capture("paper_card_clicked", eventData);
+      if (isDebug) {
+        console.log("📊 PostHog Event: paper_card_clicked", eventData);
+      }
+    },
+    [posthog, isDebug]
+  );
+
   return {
     trackNavigationClick,
     trackLanguageSwitch,
@@ -168,5 +192,6 @@ export const usePostHogTracking = () => {
     trackCurrentMemberProfileClick,
     trackScrollDepth,
     trackSectionVisibility,
+    trackPaperClick,
   };
 }; 


### PR DESCRIPTION
## Summary

Adds a `paper_card_clicked` PostHog event so we can see which articles are actually opened :) 

### Properties
`paperSlug, paperTitle, paperTag, paperLang, paperAuthor, position, page: "papers"`

## Why

`/papers` had zero tracking. Pageviews were captured automatically, but there was no signal on which article anyone actually opens. 

## Smoke Test

<img width="1725" height="1084" alt="image" src="https://github.com/user-attachments/assets/9030a997-02f1-483e-82bf-64b05cb8296c" />