### PR TITLE
fix(papers): translate 'por' byline and PT paper titles in EN locale

### DIFF
--- a/src/app/papers/page.tsx
+++ b/src/app/papers/page.tsx
@@ -40,7 +40,7 @@ export default function PapersPage() {
                 <p className="paper-card-desc">{p.desc}</p>
               </div>
               <div className="paper-card-footer">
-                <span className="kicker" style={{ color: 'var(--ink-muted)' }}>por {p.author}</span>
+                <span className="kicker" style={{ color: 'var(--ink-muted)' }}>{t('papers.by')} {p.author}</span>
                 <span className="btn btn--ghost" style={{ fontSize: 13, padding: '10px 18px' }}>
                   {t('papers.cta')} <span className="arrow">→</span>
                 </span>

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -95,11 +95,12 @@
     "title": "Reading for those who want to go further.",
     "lede": "Articles and research produced by the Trilha community.",
     "cta": "Read paper",
+    "by": "by",
     "items": [
       {
         "slug": "fullstack-paper",
         "tag": "Fullstack",
-        "title": "Fullstack, do Zero",
+        "title": "Fullstack, from Zero",
         "desc": "A friendly article for newcomers on how frontend and backend connect and where to start.",
         "lang": "PT",
         "author": "Luigi Schmitt"
@@ -115,7 +116,7 @@
       {
         "slug": "de-dados-brutos-a-decisoes-inteligentes",
         "tag": "Data Science",
-        "title": "De Dados Brutos a Decisões Inteligentes",
+        "title": "From Raw Data to Smart Decisions",
         "desc": "A journey from raw data to informed decisions — through EDA, modeling, and the intuition that connects both worlds.",
         "lang": "PT",
         "author": "Nicole Costa"
@@ -131,7 +132,7 @@
       {
         "slug": "git-paper",
         "tag": "Git",
-        "title": "Git, do zero",
+        "title": "Git, from zero",
         "desc": "A friendly version-control paper for those who hear commit, push, branch and just nod along.",
         "lang": "PT",
         "author": "Kruta"

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -94,6 +94,7 @@
     "title": "Leitura para quem quer ir além.",
     "lede": "Artigos e pesquisas produzidos pela comunidade Trilha.",
     "cta": "Ler artigo",
+    "by": "por",
     "items": [
       {
         "slug": "fullstack-paper",


### PR DESCRIPTION
On the /papers page, even with EN selected, the "por" byline and the Portuguese paper titles ("Fullstack, do Zero", "De Dados Brutos a Decisões Inteligentes", "Git, do zero") were showing in Portuguese.

- Replace the hardcoded "por" with `t('papers.by')` (PT: "por", EN: "by")
- Translate the PT paper titles in the EN locale (the PT badge still indicates the paper's actual language)

<img width="1709" height="956" alt="image" src="https://github.com/user-attachments/assets/29be769e-a407-490a-aadd-40c7b0605134" />
<img width="1709" height="960" alt="image" src="https://github.com/user-attachments/assets/2a9b26fc-de4d-4d25-a20f-c7a9b581c7ab" />
