### PR TITLE
fix: add quotes to material descriptions with colons

### DIFF
--- a/src/content/materiais/1-introducao-ao-python/11-appendix/index.md
+++ b/src/content/materiais/1-introducao-ao-python/11-appendix/index.md
@@ -1,6 +1,6 @@
 ---
 title: 11. Appendix
-description: Configure seu ambiente de desenvolvimento Python com as ferramentas essenciais: venv para isolar projetos, pip para gerenciar pacotes e uv como alternativa moderna e eficiente.
+description: "Configure seu ambiente de desenvolvimento Python com as ferramentas essenciais: venv para isolar projetos, pip para gerenciar pacotes e uv como alternativa moderna e eficiente."
 category: Programação
 order: 11
 ---

--- a/src/content/materiais/1-introducao-ao-python/12-exemplo-pratico/index.md
+++ b/src/content/materiais/1-introducao-ao-python/12-exemplo-pratico/index.md
@@ -1,6 +1,6 @@
 ---
 title: 12. Exemplo Prático
-description: Coloque em prática tudo que você aprendeu construindo um Monitor de Sistema do zero: POO, herança, abstração, bibliotecas e frameworks com Streamlit e Gradio.
+description: "Coloque em prática tudo que você aprendeu construindo um Monitor de Sistema do zero: POO, herança, abstração, bibliotecas e frameworks com Streamlit e Gradio."
 category: Programação
 order: 12
 ---


### PR DESCRIPTION
Tinha um errinho simples em dois arquivos `.md` que tavam fazendo o uso de dois pontos nas descrições sem usar as aspas, o que causava falha na leitura do YAML.