### PR TITLE
feat(aulas): add Aulas page with class schedule, individual class page.

### DIFF
--- a/src/app/api/submit-aula/route.ts
+++ b/src/app/api/submit-aula/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const sheetsUrl = process.env.SHEETS_URL;
+  if (!sheetsUrl) {
+    return NextResponse.json({ error: 'Not configured' }, { status: 500 });
+  }
+
+  const body = await req.json();
+
+  await fetch(sheetsUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/plain' },
+    body: JSON.stringify(body),
+  });
+
+  return NextResponse.json({ result: 'ok' });
+}

--- a/src/app/aulas/[slug]/page.tsx
+++ b/src/app/aulas/[slug]/page.tsx
@@ -7,20 +7,24 @@ import { useTranslation } from '@/hooks/useTranslation';
 type AulaLink = { label: string; url: string };
 type Aula = {
   number: string;
+  category: string;
   title: string;
   description: string;
   embedUrl: string;
   canvaUrl: string;
   date?: string;
   deadline?: string;
+  taskType?: string;
   homework?: string;
   links?: AulaLink[];
 };
+
 
 export default function AulaPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = use(params);
   const { t } = useTranslation();
   const aulas = t<Aula[]>('aulas.items');
+  const categories = t<Record<string, string>>('aulas.categories');
   const aula = aulas.find((a) => a.number === slug);
 
   const [edicao, setEdicao] = useState('');
@@ -30,13 +34,29 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
   const [notes, setNotes] = useState('');
   const [sent, setSent] = useState(false);
   const [sending, setSending] = useState(false);
+  const [formError, setFormError] = useState('');
 
   const edicoes = ['2025.2', '2026.1', '2026.2', '2027.1', '2027.2'];
 
   if (!aula) return null;
 
+  const isMini = aula.taskType === 'miniprojeto';
+  const taskTitle = isMini ? t('aulas.miniprojetoTitle') : t('aulas.homeworkTitle');
+  const categoryLabel = categories?.[aula.category] ?? '';
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setFormError('');
+
+    if (!edicao || !name || !email || !taskLink) {
+      setFormError(t('aulas.form.errorRequired'));
+      return;
+    }
+    if (!taskLink.startsWith('https://github.com/')) {
+      setFormError(t('aulas.form.errorGithub'));
+      return;
+    }
+
     setSending(true);
     try {
       await fetch('/api/submit-aula', {
@@ -72,6 +92,11 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
             <span className="kicker tag-dot" style={{ color: 'var(--mint-deep)' }}>
               {t('aulas.lessonLabel')} {aula.number}
             </span>
+            {categoryLabel && (
+              <span className={`aula-page-category aula-page-category--${aula.category}`}>
+                {categoryLabel}
+              </span>
+            )}
             {aula.date && (
               <span className="kicker" style={{ color: 'var(--ink-soft)' }}>{aula.date}</span>
             )}
@@ -80,10 +105,10 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
           <p className="aula-page-subtitle">{aula.description}</p>
         </header>
 
-        {/* Slide — smaller */}
-        <div className="aula-page-embed-outer">
-          <div className="aula-page-embed-ratio">
-            {aula.embedUrl ? (
+        {/* Slide — only when embedUrl is set */}
+        {aula.embedUrl && (
+          <div className="aula-page-embed-outer">
+            <div className="aula-page-embed-ratio">
               <iframe
                 loading="lazy"
                 className="aula-page-embed"
@@ -92,18 +117,14 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
                 allow="fullscreen"
                 allowFullScreen
               />
-            ) : (
-              <div className="aula-page-embed aula-page-embed--empty">
-                <span className="kicker">{t('aulas.comingSoon')}</span>
-              </div>
+            </div>
+            {aula.canvaUrl && (
+              <a href={aula.canvaUrl} target="_blank" rel="noopener noreferrer" className="aula-canva-link">
+                {aula.title} · Trilha
+              </a>
             )}
           </div>
-          {aula.canvaUrl && (
-            <a href={aula.canvaUrl} target="_blank" rel="noopener noreferrer" className="aula-canva-link">
-              {aula.title} · Trilha
-            </a>
-          )}
-        </div>
+        )}
 
         {/* Useful links — below slide, no title */}
         {aula.links && aula.links.length > 0 && (
@@ -118,9 +139,9 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
           </ul>
         )}
 
-        {/* Tarefa */}
-        <div className="aula-tarefa">
-          <h1 className="aula-tarefa-h1">{t('aulas.homeworkTitle')}</h1>
+        {/* Tarefa / Mini-Projeto — only when deadline is set */}
+        {aula.deadline && <div className="aula-tarefa">
+          <h1 className="aula-tarefa-h1">{taskTitle}</h1>
           {aula.deadline && (
             <p className="aula-page-deadline" style={{ marginBottom: 32 }}>
               {t('aulas.deadlineLabel')}: {aula.deadline}
@@ -153,7 +174,6 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
                   <label className="aulas-form-field">
                     <span className="aulas-form-label">{t('aulas.form.edicao')}</span>
                     <select
-                      required
                       value={edicao}
                       onChange={(e) => setEdicao(e.target.value)}
                       className="aulas-input"
@@ -169,7 +189,6 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
                       <span className="aulas-form-label">{t('aulas.form.name')}</span>
                       <input
                         type="text"
-                        required
                         value={name}
                         onChange={(e) => setName(e.target.value)}
                         placeholder={t('aulas.form.namePlaceholder')}
@@ -180,7 +199,6 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
                       <span className="aulas-form-label">{t('aulas.form.email')}</span>
                       <input
                         type="email"
-                        required
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                         placeholder={t('aulas.form.emailPlaceholder')}
@@ -208,6 +226,9 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
                       className="aulas-input aulas-textarea"
                     />
                   </label>
+                  {formError && (
+                    <p className="aulas-form-error">{formError}</p>
+                  )}
                   <button type="submit" className="btn btn--mint" disabled={sending}>
                     {sending
                       ? t('aulas.form.sending')
@@ -217,7 +238,7 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
               )}
             </div>
           </div>
-        </div>
+        </div>}
 
       </div>
       </div>

--- a/src/app/aulas/[slug]/page.tsx
+++ b/src/app/aulas/[slug]/page.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { use, useState } from 'react';
+import Link from 'next/link';
+import { useTranslation } from '@/hooks/useTranslation';
+
+type AulaLink = { label: string; url: string };
+type Aula = {
+  number: string;
+  title: string;
+  description: string;
+  embedUrl: string;
+  canvaUrl: string;
+  date?: string;
+  deadline?: string;
+  homework?: string;
+  links?: AulaLink[];
+};
+
+export default function AulaPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = use(params);
+  const { t } = useTranslation();
+  const aulas = t<Aula[]>('aulas.items');
+  const aula = aulas.find((a) => a.number === slug);
+
+  const [edicao, setEdicao] = useState('');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [taskLink, setTaskLink] = useState('');
+  const [notes, setNotes] = useState('');
+  const [sent, setSent] = useState(false);
+  const [sending, setSending] = useState(false);
+
+  const edicoes = ['2025.2', '2026.1', '2026.2', '2027.1', '2027.2'];
+
+  if (!aula) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSending(true);
+    try {
+      await fetch('/api/submit-aula', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          edition: edicao,
+          aula: `Aula ${aula.number} — ${aula.title}`,
+          name,
+          email,
+          'link-da-tarefa': taskLink,
+          observacoes: notes,
+        }),
+      });
+      setSent(true);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <section className="section">
+      <div className="container">
+      <div className="aula-page-inner">
+
+        <Link href="/aulas" className="aula-back">
+          ← {t('aulas.back')}
+        </Link>
+
+        {/* Header */}
+        <header className="aula-page-header">
+          <div className="aula-page-header-meta">
+            <span className="kicker tag-dot" style={{ color: 'var(--mint-deep)' }}>
+              {t('aulas.lessonLabel')} {aula.number}
+            </span>
+            {aula.date && (
+              <span className="kicker" style={{ color: 'var(--ink-soft)' }}>{aula.date}</span>
+            )}
+          </div>
+          <h1 className="display aula-page-title">{aula.title}</h1>
+          <p className="aula-page-subtitle">{aula.description}</p>
+        </header>
+
+        {/* Slide — smaller */}
+        <div className="aula-page-embed-outer">
+          <div className="aula-page-embed-ratio">
+            {aula.embedUrl ? (
+              <iframe
+                loading="lazy"
+                className="aula-page-embed"
+                src={aula.embedUrl}
+                title={aula.title}
+                allow="fullscreen"
+                allowFullScreen
+              />
+            ) : (
+              <div className="aula-page-embed aula-page-embed--empty">
+                <span className="kicker">{t('aulas.comingSoon')}</span>
+              </div>
+            )}
+          </div>
+          {aula.canvaUrl && (
+            <a href={aula.canvaUrl} target="_blank" rel="noopener noreferrer" className="aula-canva-link">
+              {aula.title} · Trilha
+            </a>
+          )}
+        </div>
+
+        {/* Useful links — below slide, no title */}
+        {aula.links && aula.links.length > 0 && (
+          <ul className="aula-useful-links">
+            {aula.links.map((link) => (
+              <li key={link.url}>
+                <a href={link.url} target="_blank" rel="noopener noreferrer">
+                  {link.label} <span className="arrow">→</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {/* Tarefa */}
+        <div className="aula-tarefa">
+          <h1 className="aula-tarefa-h1">{t('aulas.homeworkTitle')}</h1>
+          {aula.deadline && (
+            <p className="aula-page-deadline" style={{ marginBottom: 32 }}>
+              {t('aulas.deadlineLabel')}: {aula.deadline}
+            </p>
+          )}
+
+          <div className="aula-tarefa-grid">
+            {/* Descrição */}
+            <div>
+              <h2 className="aula-tarefa-h2">{t('aulas.descricaoTitle')}</h2>
+              {aula.homework && (
+                <div className="aula-homework-box">
+                  <p>{aula.homework}</p>
+                </div>
+              )}
+            </div>
+
+            {/* Submeter */}
+            <div>
+              <h2 className="aula-tarefa-h2">{t('aulas.submeterTitle')}</h2>
+              {sent ? (
+                <div className="aulas-form-success">
+                  <p className="display" style={{ fontSize: 'clamp(18px, 2vw, 24px)' }}>
+                    {t('aulas.form.successTitle')}
+                  </p>
+                  <p style={{ color: 'var(--ink-soft)' }}>{t('aulas.form.successBody')}</p>
+                </div>
+              ) : (
+                <form className="aulas-form" onSubmit={handleSubmit} noValidate>
+                  <label className="aulas-form-field">
+                    <span className="aulas-form-label">{t('aulas.form.edicao')}</span>
+                    <select
+                      required
+                      value={edicao}
+                      onChange={(e) => setEdicao(e.target.value)}
+                      className="aulas-input"
+                    >
+                      <option value="" disabled>{t('aulas.form.edicaoPlaceholder')}</option>
+                      {edicoes.map((ed) => (
+                        <option key={ed} value={ed}>{ed}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <div className="aulas-form-row">
+                    <label className="aulas-form-field">
+                      <span className="aulas-form-label">{t('aulas.form.name')}</span>
+                      <input
+                        type="text"
+                        required
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        placeholder={t('aulas.form.namePlaceholder')}
+                        className="aulas-input"
+                      />
+                    </label>
+                    <label className="aulas-form-field">
+                      <span className="aulas-form-label">{t('aulas.form.email')}</span>
+                      <input
+                        type="email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder={t('aulas.form.emailPlaceholder')}
+                        className="aulas-input"
+                      />
+                    </label>
+                  </div>
+                  <label className="aulas-form-field">
+                    <span className="aulas-form-label">{t('aulas.form.taskLink')}</span>
+                    <input
+                      type="text"
+                      value={taskLink}
+                      onChange={(e) => setTaskLink(e.target.value)}
+                      placeholder={t('aulas.form.taskLinkPlaceholder')}
+                      className="aulas-input"
+                    />
+                  </label>
+                  <label className="aulas-form-field">
+                    <span className="aulas-form-label">{t('aulas.form.notes')}</span>
+                    <textarea
+                      rows={4}
+                      value={notes}
+                      onChange={(e) => setNotes(e.target.value)}
+                      placeholder={t('aulas.form.notesPlaceholder')}
+                      className="aulas-input aulas-textarea"
+                    />
+                  </label>
+                  <button type="submit" className="btn btn--mint" disabled={sending}>
+                    {sending
+                      ? t('aulas.form.sending')
+                      : <>{t('aulas.form.submitBtn')} <span className="arrow">→</span></>}
+                  </button>
+                </form>
+              )}
+            </div>
+          </div>
+        </div>
+
+      </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/aulas/layout.tsx
+++ b/src/app/aulas/layout.tsx
@@ -1,0 +1,12 @@
+import NavBar from '@/components/NavBar';
+import Footer from '@/components/Footer';
+
+export default function AulasLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <NavBar />
+      <main className="shell">{children}</main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/aulas/page.tsx
+++ b/src/app/aulas/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslation } from '@/hooks/useTranslation';
+
+type Aula = {
+  number: string;
+  title: string;
+  description: string;
+  embedUrl: string;
+  date?: string;
+  deadline?: string;
+};
+
+export default function AulasPage() {
+  const { t } = useTranslation();
+  const aulas = t<Aula[]>('aulas.items');
+
+  return (
+    <section className="section">
+      <div className="container">
+        <header className="section-head">
+          <p className="eyebrow">{t('aulas.eyebrow')}</p>
+          <h2>{t('aulas.title')}</h2>
+          <p className="lede">{t('aulas.lede')}</p>
+        </header>
+
+        <div className="aulas-schedule">
+          {aulas.map((aula) => {
+            const hasSlide = Boolean(aula.embedUrl);
+            return (
+              <Link key={aula.number} href={`/aulas/${aula.number}`} className="aula-scard">
+                <div className="aula-scard-num">
+                  <span>{aula.number}</span>
+                </div>
+
+                <div className="aula-scard-body">
+                  <h3 className="aula-scard-title">{aula.title}</h3>
+                  <p className="aula-scard-desc">{aula.description}</p>
+                </div>
+
+                <div className="aula-scard-right">
+                  {aula.date ? (
+                    <div className="aula-scard-dates">
+                      <span className="aula-scard-date">{aula.date}</span>
+                      {aula.deadline && (
+                        <span className="aula-scard-deadline">
+                          {t('aulas.deadlineLabel')}: {aula.deadline}
+                        </span>
+                      )}
+                    </div>
+                  ) : (
+                    <span className="aula-scard-soon">{t('aulas.comingSoon')}</span>
+                  )}
+                  <span className={`aula-scard-status ${hasSlide ? 'aula-scard-status--on' : ''}`}>
+                    {hasSlide ? t('aulas.available') : t('aulas.comingSoon')}
+                  </span>
+                </div>
+
+                <span className="aula-scard-arrow">→</span>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/aulas/page.tsx
+++ b/src/app/aulas/page.tsx
@@ -5,16 +5,38 @@ import { useTranslation } from '@/hooks/useTranslation';
 
 type Aula = {
   number: string;
+  category: string;
   title: string;
   description: string;
   embedUrl: string;
   date?: string;
+  dateISO?: string;
   deadline?: string;
+  taskType?: string;
 };
+
+function getDateState(dateISO?: string): 'past' | 'today' | 'upcoming' {
+  if (!dateISO) return 'upcoming';
+  const today = new Date().toISOString().slice(0, 10);
+  if (dateISO < today) return 'past';
+  if (dateISO === today) return 'today';
+  return 'upcoming';
+}
 
 export default function AulasPage() {
   const { t } = useTranslation();
   const aulas = t<Aula[]>('aulas.items');
+  const categories = t<Record<string, string>>('aulas.categories');
+
+  const groups: { category: string; items: Aula[] }[] = [];
+  for (const aula of aulas) {
+    const last = groups[groups.length - 1];
+    if (last && last.category === aula.category) {
+      last.items.push(aula);
+    } else {
+      groups.push({ category: aula.category, items: [aula] });
+    }
+  }
 
   return (
     <section className="section">
@@ -26,39 +48,61 @@ export default function AulasPage() {
         </header>
 
         <div className="aulas-schedule">
-          {aulas.map((aula) => {
-            const hasSlide = Boolean(aula.embedUrl);
+          {groups.map(({ category, items }) => {
+            const categoryLabel = categories?.[category] ?? category;
             return (
-              <Link key={aula.number} href={`/aulas/${aula.number}`} className="aula-scard">
-                <div className="aula-scard-num">
-                  <span>{aula.number}</span>
+              <div key={category} className="aulas-group">
+                <div className={`aulas-group-header aulas-group-header--${category}`}>
+                  <span className="aulas-group-label">{categoryLabel}</span>
                 </div>
+                {items.map((aula) => {
+                  const hasSlide = Boolean(aula.embedUrl);
+                  const isMini = aula.taskType === 'miniprojeto';
+                  const dateState = getDateState(aula.dateISO);
+                  return (
+                    <Link
+                      key={aula.number}
+                      href={`/aulas/${aula.number}`}
+                      className={`aula-scard aula-scard--${dateState}`}
+                    >
+                      <div className="aula-scard-num">
+                        <span>{aula.number}</span>
+                      </div>
 
-                <div className="aula-scard-body">
-                  <h3 className="aula-scard-title">{aula.title}</h3>
-                  <p className="aula-scard-desc">{aula.description}</p>
-                </div>
+                      <div className="aula-scard-body">
+                        <div className="aula-scard-title-row">
+                          <h3 className="aula-scard-title">{aula.title}</h3>
+                          {dateState === 'today' && (
+                            <span className="aula-scard-today-tag">{t('aulas.today')}</span>
+                          )}
+                          {isMini && <span className="aula-scard-mini-tag">Mini-Projeto</span>}
+                        </div>
+                        <p className="aula-scard-desc">{aula.description}</p>
+                      </div>
 
-                <div className="aula-scard-right">
-                  {aula.date ? (
-                    <div className="aula-scard-dates">
-                      <span className="aula-scard-date">{aula.date}</span>
-                      {aula.deadline && (
-                        <span className="aula-scard-deadline">
-                          {t('aulas.deadlineLabel')}: {aula.deadline}
+                      <div className="aula-scard-right">
+                        {aula.date ? (
+                          <div className="aula-scard-dates">
+                            <span className="aula-scard-date">{aula.date}</span>
+                            {aula.deadline && (
+                              <span className="aula-scard-deadline">
+                                {t('aulas.deadlineLabel')}: {aula.deadline}
+                              </span>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="aula-scard-soon">{t('aulas.comingSoon')}</span>
+                        )}
+                        <span className={`aula-scard-status ${hasSlide ? 'aula-scard-status--on' : ''}`}>
+                          {hasSlide ? t('aulas.available') : t('aulas.comingSoon')}
                         </span>
-                      )}
-                    </div>
-                  ) : (
-                    <span className="aula-scard-soon">{t('aulas.comingSoon')}</span>
-                  )}
-                  <span className={`aula-scard-status ${hasSlide ? 'aula-scard-status--on' : ''}`}>
-                    {hasSlide ? t('aulas.available') : t('aulas.comingSoon')}
-                  </span>
-                </div>
+                      </div>
 
-                <span className="aula-scard-arrow">→</span>
-              </Link>
+                      <span className="aula-scard-arrow">→</span>
+                    </Link>
+                  );
+                })}
+              </div>
             );
           })}
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -760,6 +760,83 @@ button { font-family: inherit; cursor: pointer; }
 .aula-scard-arrow { font-size: 20px; color: var(--ink-soft); transition: transform .25s cubic-bezier(.2,.8,.3,1), color .15s ease; }
 .aula-scard:hover .aula-scard-arrow { transform: translateX(4px); color: var(--ink); }
 
+/* Date-state variants */
+.aula-scard--past { opacity: 0.45; }
+.aula-scard--past:hover { opacity: 0.75; }
+.aula-scard--today { border-bottom-color: transparent; background: color-mix(in srgb, var(--mint-deep) 6%, transparent); border-radius: var(--radius-s); margin-inline: -24px; padding-inline: 24px; }
+.aula-scard--today:hover { background: color-mix(in srgb, var(--mint-deep) 10%, transparent); }
+.aula-scard--today .aula-scard-num { background: var(--mint-deep); color: var(--cream); border-color: transparent; }
+
+/* Today badge — flex sibling of the title */
+.aula-scard-today-tag {
+  display: inline-block;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: var(--mint-deep);
+  color: var(--cream);
+}
+
+/* Category group — schedule list */
+.aulas-group { display: contents; }
+.aulas-group-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 28px 0 4px;
+}
+.aulas-group-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 5px 12px;
+  border-radius: 6px;
+}
+.aulas-group-header--python  .aulas-group-label { background: rgba(55, 118, 171, 0.1); color: #2a6396; }
+.aulas-group-header--dados   .aulas-group-label { background: rgba(219, 121, 40, 0.1); color: #b3621c; }
+.aulas-group-header--fullstack .aulas-group-label { background: rgba(16, 148, 130, 0.1); color: #0e7a6c; }
+.aulas-group-header--pitch   .aulas-group-label { background: rgba(100, 80, 160, 0.1); color: #5b3fa8; }
+
+/* Title + mini-projeto tag on the same row */
+.aula-scard-title-row { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.aula-scard-title-row .aula-scard-title { margin: 0; }
+.aula-scard-mini-tag {
+  display: inline-block;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: rgba(100, 80, 160, 0.1);
+  color: #5b3fa8;
+}
+
+/* Category badge — detail page header */
+.aula-page-category {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 4px;
+}
+.aula-page-category--python    { background: rgba(55, 118, 171, 0.12); color: #2a6396; }
+.aula-page-category--dados     { background: rgba(219, 121, 40, 0.12); color: #b3621c; }
+.aula-page-category--fullstack { background: rgba(16, 148, 130, 0.12); color: #0e7a6c; }
+.aula-page-category--pitch     { background: rgba(100, 80, 160, 0.12); color: #5b3fa8; }
+
 /* AULAS — INDIVIDUAL CLASS PAGE (/aulas/[slug]) */
 .aula-back {
   display: inline-flex;
@@ -955,6 +1032,15 @@ button { font-family: inherit; cursor: pointer; }
 .aulas-input::placeholder { color: var(--ink-soft); opacity: 0.55; }
 select.aulas-input { cursor: pointer; }
 .aulas-textarea { resize: vertical; min-height: 120px; }
+.aulas-form-error {
+  font-size: 13px;
+  color: var(--warn);
+  padding: 10px 14px;
+  background: rgba(194, 98, 46, 0.08);
+  border: 1px solid rgba(194, 98, 46, 0.25);
+  border-radius: var(--radius-s);
+  margin: 0;
+}
 .aulas-form-success {
   display: flex;
   flex-direction: column;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -700,6 +700,279 @@ button { font-family: inherit; cursor: pointer; }
 .faq-item.open .faq-a-wrap { max-height: 240px; }
 .faq-a { margin: 0 0 24px; max-width: 60ch; color: var(--ink-soft); font-size: 16px; }
 
+/* AULAS — SCHEDULE LIST (main /aulas page) */
+.aulas-schedule {
+  display: flex;
+  flex-direction: column;
+  margin-top: 56px;
+  border-top: 1px solid var(--rule);
+}
+.aula-scard {
+  display: grid;
+  grid-template-columns: 64px 1fr auto 32px;
+  gap: 32px;
+  align-items: center;
+  padding: 28px 0;
+  border-bottom: 1px solid var(--rule);
+  color: var(--ink);
+  text-decoration: none;
+  transition: background .15s ease;
+}
+.aula-scard:hover { background: var(--paper); margin-inline: -24px; padding-inline: 24px; border-radius: var(--radius-s); }
+.aula-scard-num {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-s);
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink-soft);
+  flex-shrink: 0;
+  transition: background .15s ease, color .15s ease;
+}
+.aula-scard:hover .aula-scard-num { background: var(--midnight); color: var(--cream); }
+.aula-scard-body { min-width: 0; }
+.aula-scard-title { font-size: clamp(17px, 1.8vw, 22px); font-weight: 500; margin: 0 0 6px; line-height: 1.2; }
+.aula-scard-desc { font-size: 14px; color: var(--ink-soft); margin: 0; line-height: 1.5; max-width: 54ch; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.aula-scard-right { display: flex; flex-direction: column; gap: 6px; align-items: flex-end; flex-shrink: 0; }
+.aula-scard-dates { display: flex; flex-direction: column; gap: 4px; align-items: flex-end; }
+.aula-scard-date { font-family: var(--font-mono); font-size: 12px; color: var(--ink-soft); letter-spacing: 0.03em; }
+.aula-scard-deadline { font-family: var(--font-mono); font-size: 11px; color: var(--warn); letter-spacing: 0.03em; }
+.aula-scard-soon { font-family: var(--font-mono); font-size: 11px; color: var(--ink-soft); opacity: 0.5; letter-spacing: 0.06em; text-transform: uppercase; }
+.aula-scard-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  opacity: 0.6;
+}
+.aula-scard-status::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
+.aula-scard-status--on { color: var(--mint-deep); opacity: 1; }
+.aula-scard-arrow { font-size: 20px; color: var(--ink-soft); transition: transform .25s cubic-bezier(.2,.8,.3,1), color .15s ease; }
+.aula-scard:hover .aula-scard-arrow { transform: translateX(4px); color: var(--ink); }
+
+/* AULAS — INDIVIDUAL CLASS PAGE (/aulas/[slug]) */
+.aula-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 40px;
+  transition: color .15s ease;
+}
+.aula-back:hover { color: var(--ink); }
+.aula-page-header { margin-bottom: 32px; }
+.aula-page-header-meta { display: flex; align-items: center; gap: 20px; margin-bottom: 10px; }
+.aula-page-title { font-size: clamp(32px, 5vw, 56px); margin: 0 0 10px; line-height: 1.05; }
+.aula-page-subtitle { font-size: 17px; color: var(--ink-soft); margin: 0 0 12px; line-height: 1.55; text-align: justify; }
+.aula-page-deadline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--warn);
+  background: rgba(194, 98, 46, 0.08);
+  border: 1px solid rgba(194, 98, 46, 0.25);
+  border-radius: 999px;
+  padding: 6px 14px;
+  margin: 0;
+}
+.aula-page-deadline::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--warn);
+  flex-shrink: 0;
+}
+.aula-page-embed-wrap {
+  width: 100%;
+  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.aula-page-inner {
+  max-width: 892px;
+  margin-inline: auto;
+}
+.aula-page-embed-outer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.aula-page-embed-ratio {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%; /* 16:9 — no black bars */
+  border-radius: var(--radius-m);
+  overflow: hidden;
+  border: 1px solid var(--rule);
+  background: var(--paper);
+}
+.aula-page-embed {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+.aula-page-embed--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-soft);
+}
+.aula-page-embed--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-soft);
+}
+.aula-canva-link {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  align-self: flex-start;
+  transition: color .15s ease;
+}
+.aula-canva-link:hover { color: var(--mint-deep); }
+.aula-useful-links {
+  list-style: disc;
+  padding-inline-start: 20px;
+  margin: 16px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.aula-page-links-title { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-soft); margin: 0 0 10px; }
+.aula-links-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px; }
+.aula-links-list--centered { list-style: disc; padding-inline-start: 20px; }
+.aula-links-list li a {
+  font-size: 15px;
+  color: var(--electric);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: color .15s ease;
+}
+.aula-links-list li a:hover { color: var(--mint-deep); }
+.aula-links-list li a .arrow { transition: transform .2s ease; }
+.aula-links-list li a:hover .arrow { transform: translateX(3px); }
+
+/* Tarefa section */
+.aula-tarefa {
+  margin-top: 64px;
+  padding-top: 64px;
+  border-top: 1px solid var(--rule);
+}
+.aula-tarefa-h1 {
+  font-size: clamp(28px, 4vw, 44px);
+  font-weight: 500;
+  margin: 0 0 10px;
+  line-height: 1.1;
+}
+.aula-tarefa-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  align-items: start;
+}
+.aula-tarefa-h2 {
+  font-size: 18px;
+  font-weight: 500;
+  margin: 0 0 16px;
+  color: var(--ink);
+}
+.aula-homework-box {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-m);
+  padding: 24px;
+}
+.aula-homework-box p { margin: 0; font-size: 15px; line-height: 1.7; color: var(--ink-soft); }
+
+/* AULAS — SHARED FORM */
+.aulas-form-wrap { }
+.aulas-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 660px;
+}
+.aulas-form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+.aulas-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.aulas-form-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-soft);
+  letter-spacing: 0.02em;
+}
+.aulas-input {
+  width: 100%;
+  padding: 12px 16px;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-s);
+  background: var(--cream);
+  color: var(--ink);
+  font-family: var(--font-display);
+  font-size: 15px;
+  transition: border-color .2s ease, box-shadow .2s ease;
+  outline: none;
+  box-sizing: border-box;
+}
+.aulas-input:focus {
+  border-color: var(--electric);
+  box-shadow: 0 0 0 3px rgba(28, 74, 229, 0.12);
+}
+.aulas-input::placeholder { color: var(--ink-soft); opacity: 0.55; }
+select.aulas-input { cursor: pointer; }
+.aulas-textarea { resize: vertical; min-height: 120px; }
+.aulas-form-success {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 36px;
+  background: var(--paper);
+  border-radius: var(--radius-m);
+  border: 1px solid var(--rule);
+  max-width: 660px;
+}
+
+@media (max-width: 860px) {
+  .aula-scard { grid-template-columns: 48px 1fr 28px; gap: 16px; }
+  .aula-scard-right { display: none; }
+  .aula-tarefa-grid { grid-template-columns: 1fr; gap: 40px; }
+  .aulas-form-row { grid-template-columns: 1fr; }
+}
+
 /* PAPERS */
 .papers-grid {
   display: grid;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,6 +26,7 @@ export default function Footer() {
             <li><a href="#time">{t('nav.time')}</a></li>
             <li><a href="/materiais">{t('nav.materiais')}</a></li>
             <li><a href="/papers">{t('nav.artigos')}</a></li>
+            <li><a href="/aulas">{t('nav.aulas')}</a></li>
           </ul>
         </div>
         <div className="footer-col">

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -33,6 +33,7 @@ export default function NavBar() {
     { id: 'time', label: t('nav.time'), url: '/#time' },
     { id: 'materiais', label: t('nav.materiais'), url: '/materiais' },
     { id: 'artigos', label: t('nav.artigos'), url: '/papers' },
+    { id: 'aulas', label: t('nav.aulas'), url: '/aulas' },
   ];
 
   const toggleLang = () => {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -9,7 +9,8 @@
     "projetos": "Projects",
     "time": "Team",
     "materiais": "Materials",
-    "artigos": "Papers"
+    "artigos": "Papers",
+    "aulas": "Classes"
   },
   "hero": {
     "eyebrow": "Trilha",
@@ -205,5 +206,155 @@
   "turmaPage": {
     "back": "← Back",
     "cohortLabel": "Cohort"
+  },
+  "aulas": {
+    "eyebrow": "Classes",
+    "title": "Trilha Classes.",
+    "lede": "Access recordings and materials for each class of the semester. Have a question? Send a message directly to the team.",
+    "lessonLabel": "Class",
+    "comingSoon": "Coming soon",
+    "available": "Available",
+    "dateLabel": "Date",
+    "deadlineLabel": "Due",
+    "back": "All classes",
+    "aboutTitle": "About this class",
+    "linksTitle": "Useful links",
+    "homeworkTitle": "Homework",
+    "descricaoTitle": "Description",
+    "submeterTitle": "Submission",
+    "items": [
+      {
+        "number": "01",
+        "title": "Python Basics 1",
+        "description": "Variables, primitive types, operators, and first scripts. The foundation for writing any Python program.",
+        "embedUrl": "https://www.canva.com/design/DAHBCocu1jA/oOEHWdZww_tgWoTxUAPKsA/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBCocu1jA/oOEHWdZww_tgWoTxUAPKsA/view?utm_content=DAHBCocu1jA&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "June 12, 2026",
+        "deadline": "June 18, 2026",
+        "homework": "Write two programs: (1) one that reads the user's name, age, and city and prints a personalized greeting; (2) one that reads an integer and prints whether it is positive, negative, or zero. Push both .py files to a GitHub repository.",
+        "links": [
+          { "label": "Official Python 3 tutorial", "url": "https://docs.python.org/3/tutorial/index.html" },
+          { "label": "Python Tutor — visualize your code execution", "url": "https://pythontutor.com/" },
+          { "label": "W3Schools — Python Basics", "url": "https://www.w3schools.com/python/python_intro.asp" }
+        ]
+      },
+      {
+        "number": "02",
+        "title": "Python Basics 2",
+        "description": "Conditionals, loops, and control flow logic. How to structure a program's logic from start to finish.",
+        "embedUrl": "https://www.canva.com/design/DAHBCrdmSq4/EQXDzhpmoiq5MxbrOYGH7A/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBCrdmSq4/EQXDzhpmoiq5MxbrOYGH7A/view?utm_content=DAHBCrdmSq4&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "June 19, 2026",
+        "deadline": "June 25, 2026",
+        "homework": "Write a function that calculates the factorial of a number using a loop. Then write a program that prints the first N terms of the Fibonacci sequence, where N is read from the user. Push both .py files to a GitHub repository.",
+        "links": [
+          { "label": "Python — control flow", "url": "https://docs.python.org/3/tutorial/controlflow.html" },
+          { "label": "Python — defining functions", "url": "https://docs.python.org/3/tutorial/controlflow.html#defining-functions" },
+          { "label": "Practice problems — HackerRank Python", "url": "https://www.hackerrank.com/domains/python" }
+        ]
+      },
+      {
+        "number": "03",
+        "title": "Python Basics 3 — OOP",
+        "description": "Object-oriented programming in practice: classes, attributes, methods, and inheritance. Modeling real problems with objects.",
+        "embedUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?utm_content=DAHAjlieHS0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "July 3, 2026",
+        "deadline": "July 9, 2026",
+        "homework": "Homework coming soon.",
+        "links": [
+          { "label": "Python — classes and objects", "url": "https://docs.python.org/3/tutorial/classes.html" }
+        ]
+      },
+      {
+        "number": "04",
+        "title": "Python Basics 3 — Frameworks & Libraries",
+        "description": "The Python ecosystem: pip, virtual environments, and the libraries every developer needs to know.",
+        "embedUrl": "https://www.canva.com/design/DAHBClIMRP8/9kIAewlHHH-pK44YeYLSxw/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBClIMRP8/9kIAewlHHH-pK44YeYLSxw/view?utm_content=DAHBClIMRP8&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "June 26, 2026",
+        "deadline": "July 2, 2026",
+        "homework": "Create a virtual environment with venv, install the requests library, and use it to fetch data from a public API (suggestion: https://jsonplaceholder.typicode.com/posts). Print the title of the first 5 posts. Document the process in a README.md and push everything to GitHub.",
+        "links": [
+          { "label": "pip — Python package manager", "url": "https://pip.pypa.io/en/stable/" },
+          { "label": "requests documentation", "url": "https://requests.readthedocs.io/en/latest/" },
+          { "label": "JSONPlaceholder — free test API", "url": "https://jsonplaceholder.typicode.com/" },
+          { "label": "Python venv — virtual environments", "url": "https://docs.python.org/3/library/venv.html" }
+        ]
+      },
+      {
+        "number": "05",
+        "title": "Data 1 — Intro & Data Engineering",
+        "description": "What data engineering is, pipelines, and how raw data becomes usable information in real systems.",
+        "embedUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?utm_content=DAHLV2G9YO0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Homework coming soon.",
+        "links": []
+      },
+      {
+        "number": "06",
+        "title": "Data 2 — Data Analysis",
+        "description": "Exploration and visualization with pandas and matplotlib. Extracting patterns and insights from datasets.",
+        "embedUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?utm_content=DAHBCznivZs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Homework coming soon.",
+        "links": []
+      },
+      {
+        "number": "07",
+        "title": "Data 3 — ML",
+        "description": "Introduction to Machine Learning: supervised models, training, testing, and how to evaluate performance in practice.",
+        "embedUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?utm_content=DAHAHCMaCH0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Homework coming soon.",
+        "links": []
+      },
+      {
+        "number": "08",
+        "title": "FullStack 1 — Backend",
+        "description": "Building RESTful APIs with Python. Routes, requests, responses, and the logic that lives on the server.",
+        "embedUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?utm_content=DAHCdA8c7fI&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Homework coming soon.",
+        "links": []
+      },
+      {
+        "number": "09",
+        "title": "FullStack 2 — Database",
+        "description": "Relational modeling, SQL, and connecting a database to the backend. Data persistence in practice.",
+        "embedUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?utm_content=DAHBC_b0Jbs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Homework coming soon.",
+        "links": []
+      },
+      {
+        "number": "10",
+        "title": "FullStack 3 — Frontend",
+        "description": "HTML, CSS, and JavaScript applied: building interfaces that talk to the backend and make sense for the user.",
+        "embedUrl": "https://www.canva.com/design/DAHIPYNNMlM/gZ7J69hsNILgyqoOJsBing/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHIPYNNMlM/gZ7J69hsNILgyqoOJsBing/view?utm_content=DAHIPYNNMlM&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Homework coming soon.",
+        "links": []
+      }
+    ],
+    "form": {
+      "eyebrow": "Submit",
+      "submitTitle": "Submit homework",
+      "submitLede": "Send the link to your solution and any notes you think are relevant.",
+      "submitBtn": "Submit homework",
+      "edicao": "Trilha edition",
+      "edicaoPlaceholder": "Select your cohort",
+      "name": "Name",
+      "email": "Email",
+      "taskLink": "Homework link",
+      "notes": "Notes",
+      "namePlaceholder": "Your full name",
+      "emailPlaceholder": "you@email.com",
+      "taskLinkPlaceholder": "https://github.com/your-username/your-repo",
+      "notesPlaceholder": "Any notes about your solution? (optional)",
+      "sending": "Sending...",
+      "successTitle": "Homework submitted!",
+      "successBody": "We received your submission. The team will get back to you soon."
+    }
   }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -15,7 +15,12 @@
   "hero": {
     "eyebrow": "Trilha",
     "titleA": "A practical path to",
-    "flips": ["learn.", "grow.", "connect.", "start."],
+    "flips": [
+      "learn.",
+      "grow.",
+      "connect.",
+      "start."
+    ],
     "lede": "Trilha is a free program built by UFPB students to support people arriving at the Computing Center. Classes, mentoring, talks, and a hackathon — all in one semester.",
     "ctaPrimary": "How it works",
     "ctaSecondary": "Meet the team"
@@ -25,10 +30,26 @@
     "title": "More than a course. A network for life.",
     "lede": "Trilha started in 2024 as senior students' answer to a simple question: what was missing for us when we arrived? Today it is a program of classes, mentoring, talks, and events — built by people who walked the path already.",
     "pillars": [
-      { "tag": "Hands-on classes", "title": "A curriculum aimed at industry", "body": "Python, web, data, and engineering fundamentals — taught by tutors already working in the field. Applied to a real project at the end of each semester." },
-      { "tag": "1-1 mentoring", "title": "Support that doesn't end with the class", "body": "Every student is paired with a senior mentor. The conversations continue long after the semester ends." },
-      { "tag": "Talks", "title": "Guests from industry and research", "body": "Engineers, founders, and researchers bring back what is actually happening in the market and in academia." },
-      { "tag": "Hackathon", "title": "Putting it all together at the end", "body": "Each cohort closes with a themed hackathon — teams build from scratch in a few days, the best way to consolidate everything learned." }
+      {
+        "tag": "Hands-on classes",
+        "title": "A curriculum aimed at industry",
+        "body": "Python, web, data, and engineering fundamentals — taught by tutors already working in the field. Applied to a real project at the end of each semester."
+      },
+      {
+        "tag": "1-1 mentoring",
+        "title": "Support that doesn't end with the class",
+        "body": "Every student is paired with a senior mentor. The conversations continue long after the semester ends."
+      },
+      {
+        "tag": "Talks",
+        "title": "Guests from industry and research",
+        "body": "Engineers, founders, and researchers bring back what is actually happening in the market and in academia."
+      },
+      {
+        "tag": "Hackathon",
+        "title": "Putting it all together at the end",
+        "body": "Each cohort closes with a themed hackathon — teams build from scratch in a few days, the best way to consolidate everything learned."
+      }
     ]
   },
   "numbers": {
@@ -49,10 +70,34 @@
     "lede": "Each cohort marks a version of Trilha. Meet the people who came through and what each edition built.",
     "studentsSuffix": "students",
     "items": [
-      { "period": "2024.1", "title": "First cohort", "students": 14, "theme": "Where it all started — Python, web, and the first hackathon.", "img": "/assets/turmas/trilha2024.jpg" },
-      { "period": "2024.2", "title": "Second cohort", "students": 19, "theme": "Expanded curriculum, first wave of external guest speakers.", "img": "/assets/turmas/trilha2024-2.jpg" },
-      { "period": "2025.1", "title": "Third cohort", "students": 16, "theme": "Structured mentoring and a new data track.", "img": "/assets/turmas/trilha2025.jpg" },
-      { "period": "2025.2", "title": "Fourth cohort", "students": 12, "theme": "More cohorts, more projects, a community taking shape.", "img": "/assets/turmas/trilha2025-2.jpeg" }
+      {
+        "period": "2024.1",
+        "title": "First cohort",
+        "students": 14,
+        "theme": "Where it all started — Python, web, and the first hackathon.",
+        "img": "/assets/turmas/trilha2024.jpg"
+      },
+      {
+        "period": "2024.2",
+        "title": "Second cohort",
+        "students": 19,
+        "theme": "Expanded curriculum, first wave of external guest speakers.",
+        "img": "/assets/turmas/trilha2024-2.jpg"
+      },
+      {
+        "period": "2025.1",
+        "title": "Third cohort",
+        "students": 16,
+        "theme": "Structured mentoring and a new data track.",
+        "img": "/assets/turmas/trilha2025.jpg"
+      },
+      {
+        "period": "2025.2",
+        "title": "Fourth cohort",
+        "students": 12,
+        "theme": "More cohorts, more projects, a community taking shape.",
+        "img": "/assets/turmas/trilha2025-2.jpeg"
+      }
     ]
   },
   "projects": {
@@ -60,9 +105,27 @@
     "title": "What comes out of a Trilha semester.",
     "lede": "Every semester ends with a themed hackathon. Teams build from scratch in a few days — below, some of the projects. (Links and details coming soon.)",
     "items": [
-      { "tag": "2024.1", "title": "ClarIAr", "desc": "Android accessibility app that uses LLMs to generate rich, natural descriptions of on-screen images, empowering visually impaired users.", "img": "/assets/projects/clariar.png", "pitch": "https://www.youtube.com/watch?v=0b4k1lVUtO4" },
-      { "tag": "2024.2", "title": "Pixelmind", "desc": "AI-powered video editor: users upload a clip, describe the desired result, and the system automates the full edit.", "img": "/assets/projects/pixelmind.png", "pitch": "https://www.youtube.com/watch?v=DHXnobWWJjE" },
-      { "tag": "2025.1", "title": "Praxis", "desc": "Hands-on learning platform for junior devs with track-specific challenges and AI feedback. Simulate, practice, evolve.", "img": "/assets/projects/praxis.png", "pitch": "https://www.youtube.com/watch?v=v5YYfLKEvV0" }
+      {
+        "tag": "2024.1",
+        "title": "ClarIAr",
+        "desc": "Android accessibility app that uses LLMs to generate rich, natural descriptions of on-screen images, empowering visually impaired users.",
+        "img": "/assets/projects/clariar.png",
+        "pitch": "https://www.youtube.com/watch?v=0b4k1lVUtO4"
+      },
+      {
+        "tag": "2024.2",
+        "title": "Pixelmind",
+        "desc": "AI-powered video editor: users upload a clip, describe the desired result, and the system automates the full edit.",
+        "img": "/assets/projects/pixelmind.png",
+        "pitch": "https://www.youtube.com/watch?v=DHXnobWWJjE"
+      },
+      {
+        "tag": "2025.1",
+        "title": "Praxis",
+        "desc": "Hands-on learning platform for junior devs with track-specific challenges and AI feedback. Simulate, practice, evolve.",
+        "img": "/assets/projects/praxis.png",
+        "pitch": "https://www.youtube.com/watch?v=v5YYfLKEvV0"
+      }
     ]
   },
   "depo": {
@@ -144,13 +207,35 @@
     "eyebrow": "08 / FAQ",
     "title": "Questions?",
     "questions": [
-      { "q": "Is it for every major?", "a": "Yes — open to students from any major, not restricted to UFPB only." },
-      { "q": "How do I sign up?", "a": "Registrations open periodically, when each cohort ends, at the start of each academic semester." },
-      { "q": "How many cohorts run at once?", "a": "Just one cohort per semester." },
-      { "q": "Do I need to know how to program?", "a": "No. The program targets people starting out and assumes no prior experience." },
-      { "q": "Where are classes held?", "a": "At UFPB's Computing Center (CI)." },
-      { "q": "Is it free?", "a": "Yes — completely free." },
-      { "q": "What's Tiago's favorite color?", "a": "One of the most frequently asked questions at Trilha, and Tiago's favorite color is ", "easterEgg": "tiagoColor" }
+      {
+        "q": "Is it for every major?",
+        "a": "Yes — open to students from any major, not restricted to UFPB only."
+      },
+      {
+        "q": "How do I sign up?",
+        "a": "Registrations open periodically, when each cohort ends, at the start of each academic semester."
+      },
+      {
+        "q": "How many cohorts run at once?",
+        "a": "Just one cohort per semester."
+      },
+      {
+        "q": "Do I need to know how to program?",
+        "a": "No. The program targets people starting out and assumes no prior experience."
+      },
+      {
+        "q": "Where are classes held?",
+        "a": "At UFPB's Computing Center (CI)."
+      },
+      {
+        "q": "Is it free?",
+        "a": "Yes — completely free."
+      },
+      {
+        "q": "What's Tiago's favorite color?",
+        "a": "One of the most frequently asked questions at Trilha, and Tiago's favorite color is ",
+        "easterEgg": "tiagoColor"
+      }
     ],
     "colors": {
       "sunday": "Red",
@@ -200,7 +285,11 @@
     "contact": "Contact",
     "sections": "Sections",
     "locationLabel": "Location",
-    "locationLines": ["UFPB · Computing Center", "João Pessoa, Paraíba", "Brazil"],
+    "locationLines": [
+      "UFPB · Computing Center",
+      "João Pessoa, Paraíba",
+      "Brazil"
+    ],
     "rights": "All rights reserved."
   },
   "turmaPage": {
@@ -224,117 +313,276 @@
     "submeterTitle": "Submission",
     "items": [
       {
-        "number": "01",
-        "title": "Python Basics 1",
-        "description": "Variables, primitive types, operators, and first scripts. The foundation for writing any Python program.",
+        "number": "03",
+        "category": "python",
+        "title": "Variables and Fundamentals",
+        "description": "Introduction to the execution environment, variables and fundamentals, data types, operations, and conditional structures.",
         "embedUrl": "https://www.canva.com/design/DAHBCocu1jA/oOEHWdZww_tgWoTxUAPKsA/view?embed",
         "canvaUrl": "https://www.canva.com/design/DAHBCocu1jA/oOEHWdZww_tgWoTxUAPKsA/view?utm_content=DAHBCocu1jA&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
         "date": "June 12, 2026",
         "deadline": "June 18, 2026",
         "homework": "Write two programs: (1) one that reads the user's name, age, and city and prints a personalized greeting; (2) one that reads an integer and prints whether it is positive, negative, or zero. Push both .py files to a GitHub repository.",
         "links": [
-          { "label": "Official Python 3 tutorial", "url": "https://docs.python.org/3/tutorial/index.html" },
-          { "label": "Python Tutor — visualize your code execution", "url": "https://pythontutor.com/" },
-          { "label": "W3Schools — Python Basics", "url": "https://www.w3schools.com/python/python_intro.asp" }
-        ]
+          {
+            "label": "Official Python 3 tutorial",
+            "url": "https://docs.python.org/3/tutorial/index.html"
+          },
+          {
+            "label": "Python Tutor — visualize your code execution",
+            "url": "https://pythontutor.com/"
+          },
+          {
+            "label": "W3Schools — Python Basics",
+            "url": "https://www.w3schools.com/python/python_intro.asp"
+          }
+        ],
+        "dateISO": "2026-06-12"
       },
       {
-        "number": "02",
-        "title": "Python Basics 2",
-        "description": "Conditionals, loops, and control flow logic. How to structure a program's logic from start to finish.",
+        "number": "04",
+        "category": "python",
+        "title": "Loops and Functions",
+        "description": "Loops and functions. How to structure a program's logic from start to finish.",
         "embedUrl": "https://www.canva.com/design/DAHBCrdmSq4/EQXDzhpmoiq5MxbrOYGH7A/view?embed",
         "canvaUrl": "https://www.canva.com/design/DAHBCrdmSq4/EQXDzhpmoiq5MxbrOYGH7A/view?utm_content=DAHBCrdmSq4&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
         "date": "June 19, 2026",
         "deadline": "June 25, 2026",
         "homework": "Write a function that calculates the factorial of a number using a loop. Then write a program that prints the first N terms of the Fibonacci sequence, where N is read from the user. Push both .py files to a GitHub repository.",
         "links": [
-          { "label": "Python — control flow", "url": "https://docs.python.org/3/tutorial/controlflow.html" },
-          { "label": "Python — defining functions", "url": "https://docs.python.org/3/tutorial/controlflow.html#defining-functions" },
-          { "label": "Practice problems — HackerRank Python", "url": "https://www.hackerrank.com/domains/python" }
-        ]
+          {
+            "label": "Python — control flow",
+            "url": "https://docs.python.org/3/tutorial/controlflow.html"
+          },
+          {
+            "label": "Python — defining functions",
+            "url": "https://docs.python.org/3/tutorial/controlflow.html#defining-functions"
+          },
+          {
+            "label": "Practice problems — HackerRank Python",
+            "url": "https://www.hackerrank.com/domains/python"
+          }
+        ],
+        "dateISO": "2026-06-19"
       },
       {
-        "number": "03",
-        "title": "Python Basics 3 — OOP",
-        "description": "Object-oriented programming in practice: classes, attributes, methods, and inheritance. Modeling real problems with objects.",
-        "embedUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?utm_content=DAHAjlieHS0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
-        "date": "July 3, 2026",
-        "deadline": "July 9, 2026",
-        "homework": "Homework coming soon.",
-        "links": [
-          { "label": "Python — classes and objects", "url": "https://docs.python.org/3/tutorial/classes.html" }
-        ]
-      },
-      {
-        "number": "04",
-        "title": "Python Basics 3 — Frameworks & Libraries",
-        "description": "The Python ecosystem: pip, virtual environments, and the libraries every developer needs to know.",
+        "number": "05",
+        "category": "python",
+        "title": "Errors, Exceptions, and Frameworks",
+        "description": "Errors, exceptions, files, libraries, and frameworks. The Python ecosystem and how to use it in practice.",
         "embedUrl": "https://www.canva.com/design/DAHBClIMRP8/9kIAewlHHH-pK44YeYLSxw/view?embed",
         "canvaUrl": "https://www.canva.com/design/DAHBClIMRP8/9kIAewlHHH-pK44YeYLSxw/view?utm_content=DAHBClIMRP8&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
         "date": "June 26, 2026",
         "deadline": "July 2, 2026",
         "homework": "Create a virtual environment with venv, install the requests library, and use it to fetch data from a public API (suggestion: https://jsonplaceholder.typicode.com/posts). Print the title of the first 5 posts. Document the process in a README.md and push everything to GitHub.",
         "links": [
-          { "label": "pip — Python package manager", "url": "https://pip.pypa.io/en/stable/" },
-          { "label": "requests documentation", "url": "https://requests.readthedocs.io/en/latest/" },
-          { "label": "JSONPlaceholder — free test API", "url": "https://jsonplaceholder.typicode.com/" },
-          { "label": "Python venv — virtual environments", "url": "https://docs.python.org/3/library/venv.html" }
-        ]
-      },
-      {
-        "number": "05",
-        "title": "Data 1 — Intro & Data Engineering",
-        "description": "What data engineering is, pipelines, and how raw data becomes usable information in real systems.",
-        "embedUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?utm_content=DAHLV2G9YO0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
-        "homework": "Homework coming soon.",
-        "links": []
+          {
+            "label": "pip — Python package manager",
+            "url": "https://pip.pypa.io/en/stable/"
+          },
+          {
+            "label": "requests documentation",
+            "url": "https://requests.readthedocs.io/en/latest/"
+          },
+          {
+            "label": "JSONPlaceholder — free test API",
+            "url": "https://jsonplaceholder.typicode.com/"
+          },
+          {
+            "label": "Python venv — virtual environments",
+            "url": "https://docs.python.org/3/library/venv.html"
+          }
+        ],
+        "dateISO": "2026-06-26"
       },
       {
         "number": "06",
-        "title": "Data 2 — Data Analysis",
-        "description": "Exploration and visualization with pandas and matplotlib. Extracting patterns and insights from datasets.",
-        "embedUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?utm_content=DAHBCznivZs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "category": "python",
+        "title": "Object-Oriented Programming",
+        "description": "Object-oriented programming: classes, attributes, methods, and inheritance.",
+        "embedUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?utm_content=DAHAjlieHS0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "July 3, 2026",
+        "deadline": "July 9, 2026",
         "homework": "Homework coming soon.",
-        "links": []
+        "links": [
+          {
+            "label": "Python — classes and objects",
+            "url": "https://docs.python.org/3/tutorial/classes.html"
+          }
+        ],
+        "dateISO": "2026-07-03"
       },
       {
         "number": "07",
-        "title": "Data 3 — ML",
-        "description": "Introduction to Machine Learning: supervised models, training, testing, and how to evaluate performance in practice.",
-        "embedUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?utm_content=DAHAHCMaCH0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "category": "python",
+        "title": "Lists, Queues, and Stacks",
+        "description": "Linear structures: arrays/lists, queues, and stacks. How to store and organize data in memory.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "July 10, 2026",
+        "deadline": "July 16, 2026",
         "homework": "Homework coming soon.",
-        "links": []
+        "links": [],
+        "dateISO": "2026-07-10"
       },
       {
         "number": "08",
-        "title": "FullStack 1 — Backend",
-        "description": "Building RESTful APIs with Python. Routes, requests, responses, and the logic that lives on the server.",
-        "embedUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?utm_content=DAHCdA8c7fI&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "category": "python",
+        "title": "Hash Tables, Sets, and Complexity",
+        "description": "Hash tables, sets, and computational complexity. Efficiency and choosing the right structure for each problem.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "July 17, 2026",
+        "deadline": "July 23, 2026",
         "homework": "Homework coming soon.",
-        "links": []
+        "links": [],
+        "dateISO": "2026-07-17"
       },
       {
         "number": "09",
-        "title": "FullStack 2 — Database",
-        "description": "Relational modeling, SQL, and connecting a database to the backend. Data persistence in practice.",
-        "embedUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?utm_content=DAHBC_b0Jbs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
-        "homework": "Homework coming soon.",
-        "links": []
+        "category": "python",
+        "title": "Competitive Practice",
+        "description": "Hands-on class in competition format. The mini-project brings together everything you've learned about data structures.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "July 24, 2026",
+        "deadline": "July 30, 2026",
+        "taskType": "miniprojeto",
+        "homework": "Mini-Project coming soon.",
+        "links": [],
+        "dateISO": "2026-07-24"
       },
       {
         "number": "10",
-        "title": "FullStack 3 — Frontend",
-        "description": "HTML, CSS, and JavaScript applied: building interfaces that talk to the backend and make sense for the user.",
+        "category": "dados",
+        "title": "Data Engineering and Web Scraping",
+        "description": "Introduction to data engineering and web scraping in practice. How to collect, process, and transform raw data.",
+        "embedUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?utm_content=DAHLV2G9YO0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "July 31, 2026",
+        "deadline": "August 6, 2026",
+        "homework": "Homework coming soon.",
+        "links": [],
+        "dateISO": "2026-07-31"
+      },
+      {
+        "number": "11",
+        "category": "dados",
+        "title": "Exploratory Data Analysis",
+        "description": "Concepts and practice of exploratory data analysis with pandas and matplotlib.",
+        "embedUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?utm_content=DAHBCznivZs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "August 7, 2026",
+        "deadline": "August 27, 2026",
+        "homework": "Homework coming soon.",
+        "links": [],
+        "dateISO": "2026-08-07"
+      },
+      {
+        "number": "12",
+        "category": "dados",
+        "title": "Notebook Presentations",
+        "description": "Presentation and discussion of notebooks from the previous assignment. Refinement and insights.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "August 28, 2026",
+        "deadline": "September 3, 2026",
+        "homework": "Homework coming soon.",
+        "links": [],
+        "dateISO": "2026-08-28"
+      },
+      {
+        "number": "13",
+        "category": "dados",
+        "title": "Introduction to Machine Learning",
+        "description": "Introduction to Machine Learning: supervised models, training, testing, and performance evaluation.",
+        "embedUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?utm_content=DAHAHCMaCH0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "September 4, 2026",
+        "deadline": "September 10, 2026",
+        "homework": "Homework coming soon.",
+        "links": [],
+        "dateISO": "2026-09-04"
+      },
+      {
+        "number": "14",
+        "category": "dados",
+        "title": "Advanced ML Topics",
+        "description": "Advanced topics and Machine Learning mini-project. How to apply models to real-world problems.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "September 11, 2026",
+        "deadline": "September 17, 2026",
+        "taskType": "miniprojeto",
+        "homework": "Mini-Project coming soon.",
+        "links": [],
+        "dateISO": "2026-09-11"
+      },
+      {
+        "number": "15",
+        "category": "fullstack",
+        "title": "Introduction to Full Stack",
+        "description": "Introduction to full stack development: what software is, networks, and the fundamentals of APIs.",
+        "embedUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?utm_content=DAHCdA8c7fI&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "September 18, 2026",
+        "deadline": "September 24, 2026",
+        "homework": "Homework coming soon.",
+        "links": [],
+        "dateISO": "2026-09-18"
+      },
+      {
+        "number": "16",
+        "category": "fullstack",
+        "title": "API with FastAPI and Postman",
+        "description": "Backend in practice: API with FastAPI and Postman. How to persist data durably.",
+        "embedUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?utm_content=DAHBC_b0Jbs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "September 25, 2026",
+        "deadline": "October 1, 2026",
+        "homework": "Homework coming soon.",
+        "links": [],
+        "dateISO": "2026-09-25"
+      },
+      {
+        "number": "17",
+        "category": "fullstack",
+        "title": "Databases",
+        "description": "Database theory: relational modeling, SQL, and connecting data to the server.",
         "embedUrl": "https://www.canva.com/design/DAHIPYNNMlM/gZ7J69hsNILgyqoOJsBing/view?embed",
         "canvaUrl": "https://www.canva.com/design/DAHIPYNNMlM/gZ7J69hsNILgyqoOJsBing/view?utm_content=DAHIPYNNMlM&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "October 2, 2026",
+        "deadline": "October 8, 2026",
         "homework": "Homework coming soon.",
-        "links": []
+        "links": [],
+        "dateISO": "2026-10-02"
+      },
+      {
+        "number": "18",
+        "category": "fullstack",
+        "title": "SQLAlchemy and Database Integration",
+        "description": "API refinement with schemas, base models, and SQLAlchemy. Full integration of the database with the backend.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "October 9, 2026",
+        "deadline": "October 15, 2026",
+        "homework": "Homework coming soon.",
+        "links": [],
+        "dateISO": "2026-10-09"
+      },
+      {
+        "number": "19",
+        "category": "fullstack",
+        "title": "Frontend in Practice",
+        "description": "Frontend theory and practice. The mini-project closes the cycle with a complete application.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "October 16, 2026",
+        "deadline": "October 24, 2026",
+        "taskType": "miniprojeto",
+        "homework": "Mini-Project coming soon.",
+        "links": [],
+        "dateISO": "2026-10-16"
       }
     ],
     "form": {
@@ -354,7 +602,17 @@
       "notesPlaceholder": "Any notes about your solution? (optional)",
       "sending": "Sending...",
       "successTitle": "Homework submitted!",
-      "successBody": "We received your submission. The team will get back to you soon."
-    }
+      "successBody": "We received your submission. The team will get back to you soon.",
+      "errorRequired": "Please fill in all required fields.",
+      "errorGithub": "The homework link must be a GitHub URL (https://github.com/...)."
+    },
+    "miniprojetoTitle": "Mini-Project",
+    "categories": {
+      "python": "Python Basics",
+      "dados": "Data",
+      "fullstack": "FullStack",
+      "pitch": "Pitch"
+    },
+    "today": "Today"
   }
 }

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -15,7 +15,12 @@
   "hero": {
     "eyebrow": "Trilha",
     "titleA": "Um caminho prático para",
-    "flips": ["aprender.", "crescer.", "se conectar.", "começar."],
+    "flips": [
+      "aprender.",
+      "crescer.",
+      "se conectar.",
+      "começar."
+    ],
     "lede": "O Trilha é um programa gratuito feito por estudantes da UFPB para apoiar quem está chegando ao Centro de Informática. Aulas, mentorias, palestras e um hackathon — tudo em um semestre.",
     "ctaPrimary": "Como funciona",
     "ctaSecondary": "Conheça o time"
@@ -25,10 +30,26 @@
     "title": "Mais que um curso. Uma rede para a vida.",
     "lede": "O Trilha começou em 2024 como uma resposta de alunos veteranos a uma pergunta simples: o que faltou pra gente quando chegou na universidade? Hoje somos um programa com aulas, mentoria, palestras e eventos — feito por quem já passou pelo caminho.",
     "pillars": [
-      { "tag": "Aulas práticas", "title": "Currículo voltado pro mercado", "body": "Python, web, dados e fundamentos de engenharia — entregues por monitores que já trabalham na área. Tudo aplicado em projeto real ao final do semestre." },
-      { "tag": "Mentoria 1-1", "title": "Acompanhamento que não acaba na sala", "body": "Cada aluno tem um mentor sênior que acompanha a evolução da turma. As trocas continuam muito depois do semestre acabar." },
-      { "tag": "Palestras", "title": "Convidados de empresas e laboratórios", "body": "Engenheiros, fundadores e pesquisadores trazem o que está acontecendo de verdade no mercado e na pesquisa." },
-      { "tag": "Hackathon", "title": "Aplicar tudo no fim do semestre", "body": "A turma fecha com um hackathon temático onde os times constroem do zero — a melhor forma de consolidar o aprendizado." }
+      {
+        "tag": "Aulas práticas",
+        "title": "Currículo voltado pro mercado",
+        "body": "Python, web, dados e fundamentos de engenharia — entregues por monitores que já trabalham na área. Tudo aplicado em projeto real ao final do semestre."
+      },
+      {
+        "tag": "Mentoria 1-1",
+        "title": "Acompanhamento que não acaba na sala",
+        "body": "Cada aluno tem um mentor sênior que acompanha a evolução da turma. As trocas continuam muito depois do semestre acabar."
+      },
+      {
+        "tag": "Palestras",
+        "title": "Convidados de empresas e laboratórios",
+        "body": "Engenheiros, fundadores e pesquisadores trazem o que está acontecendo de verdade no mercado e na pesquisa."
+      },
+      {
+        "tag": "Hackathon",
+        "title": "Aplicar tudo no fim do semestre",
+        "body": "A turma fecha com um hackathon temático onde os times constroem do zero — a melhor forma de consolidar o aprendizado."
+      }
     ]
   },
   "numbers": {
@@ -49,10 +70,34 @@
     "lede": "Cada turma marca uma versão do Trilha. Conheça quem passou por aqui e o que cada edição construiu.",
     "studentsSuffix": "alunos",
     "items": [
-      { "period": "2024.1", "title": "Primeira Turma", "students": 14, "theme": "Onde tudo começou — Python, web, e o primeiro hackathon.", "img": "/assets/turmas/trilha2024.jpg" },
-      { "period": "2024.2", "title": "Segunda Turma", "students": 19, "theme": "Currículo expandido, primeira leva de palestrantes externos.", "img": "/assets/turmas/trilha2024-2.jpg" },
-      { "period": "2025.1", "title": "Terceira Turma", "students": 16, "theme": "Mentoria estruturada e nova frente de dados.", "img": "/assets/turmas/trilha2025.jpg" },
-      { "period": "2025.2", "title": "Quarta Turma", "students": 12, "theme": "Mais turmas, mais projetos, comunidade consolidada.", "img": "/assets/turmas/trilha2025-2.jpeg" }
+      {
+        "period": "2024.1",
+        "title": "Primeira Turma",
+        "students": 14,
+        "theme": "Onde tudo começou — Python, web, e o primeiro hackathon.",
+        "img": "/assets/turmas/trilha2024.jpg"
+      },
+      {
+        "period": "2024.2",
+        "title": "Segunda Turma",
+        "students": 19,
+        "theme": "Currículo expandido, primeira leva de palestrantes externos.",
+        "img": "/assets/turmas/trilha2024-2.jpg"
+      },
+      {
+        "period": "2025.1",
+        "title": "Terceira Turma",
+        "students": 16,
+        "theme": "Mentoria estruturada e nova frente de dados.",
+        "img": "/assets/turmas/trilha2025.jpg"
+      },
+      {
+        "period": "2025.2",
+        "title": "Quarta Turma",
+        "students": 12,
+        "theme": "Mais turmas, mais projetos, comunidade consolidada.",
+        "img": "/assets/turmas/trilha2025-2.jpeg"
+      }
     ]
   },
   "projects": {
@@ -60,9 +105,27 @@
     "title": "O que sai de um semestre no Trilha.",
     "lede": "Todo semestre fecha com um hackathon temático. As equipes constroem do zero em poucos dias — abaixo, alguns dos projetos. (Em breve com links e detalhes.)",
     "items": [
-      { "tag": "2024.1", "title": "ClarIAr", "desc": "App Android de acessibilidade que usa LLMs para descrever imagens da tela com naturalidade, dando mais autonomia a pessoas com deficiência visual.", "img": "/assets/projects/clariar.png", "pitch": "https://www.youtube.com/watch?v=0b4k1lVUtO4" },
-      { "tag": "2024.2", "title": "Pixelmind", "desc": "Plataforma de edição de vídeo automatizada por IA: o usuário faz upload do vídeo, descreve o resultado desejado e a edição acontece sozinha.", "img": "/assets/projects/pixelmind.png", "pitch": "https://www.youtube.com/watch?v=DHXnobWWJjE" },
-      { "tag": "2025.1", "title": "Praxis", "desc": "Plataforma de prática para devs iniciantes com desafios personalizados por trilha de carreira e feedback por IA. Simule, pratique, evolua.", "img": "/assets/projects/praxis.png", "pitch": "https://www.youtube.com/watch?v=v5YYfLKEvV0" }
+      {
+        "tag": "2024.1",
+        "title": "ClarIAr",
+        "desc": "App Android de acessibilidade que usa LLMs para descrever imagens da tela com naturalidade, dando mais autonomia a pessoas com deficiência visual.",
+        "img": "/assets/projects/clariar.png",
+        "pitch": "https://www.youtube.com/watch?v=0b4k1lVUtO4"
+      },
+      {
+        "tag": "2024.2",
+        "title": "Pixelmind",
+        "desc": "Plataforma de edição de vídeo automatizada por IA: o usuário faz upload do vídeo, descreve o resultado desejado e a edição acontece sozinha.",
+        "img": "/assets/projects/pixelmind.png",
+        "pitch": "https://www.youtube.com/watch?v=DHXnobWWJjE"
+      },
+      {
+        "tag": "2025.1",
+        "title": "Praxis",
+        "desc": "Plataforma de prática para devs iniciantes com desafios personalizados por trilha de carreira e feedback por IA. Simule, pratique, evolua.",
+        "img": "/assets/projects/praxis.png",
+        "pitch": "https://www.youtube.com/watch?v=v5YYfLKEvV0"
+      }
     ]
   },
   "depo": {
@@ -87,7 +150,7 @@
       "Backend": "/materiais/4-backend/1-introducao",
       "Banco de Dados": "/materiais/5-banco-de-dados/1-introducao",
       "Frontend": "/materiais/6-frontend/1-fundamentos-da-web"
-    }, 
+    },
     "cta": "Acessar materiais"
   },
   "papers": {
@@ -143,13 +206,35 @@
     "eyebrow": "08 / Perguntas",
     "title": "Dúvidas?",
     "questions": [
-      { "q": "É para todos os cursos?", "a": "Sim — o programa é aberto a estudantes de qualquer curso, não restrito apenas à UFPB." },
-      { "q": "Como me inscrevo?", "a": "As inscrições abrem periodicamente, sempre que uma turma termina, no início de cada semestre letivo." },
-      { "q": "Quantas turmas existem?", "a": "Apenas uma turma por semestre." },
-      { "q": "Preciso saber programar?", "a": "Não. O programa é focado em quem está começando e não exige conhecimento prévio." },
-      { "q": "Onde acontecem as aulas?", "a": "No Centro de Informática (CI) da UFPB." },
-      { "q": "É gratuito?", "a": "Sim — completamente gratuito." },
-      { "q": "Qual a cor favorita de Tiago?", "a": "Uma das perguntas mais frequentes no Trilha, e a cor favorita de Tiago é ", "easterEgg": "tiagoColor" }
+      {
+        "q": "É para todos os cursos?",
+        "a": "Sim — o programa é aberto a estudantes de qualquer curso, não restrito apenas à UFPB."
+      },
+      {
+        "q": "Como me inscrevo?",
+        "a": "As inscrições abrem periodicamente, sempre que uma turma termina, no início de cada semestre letivo."
+      },
+      {
+        "q": "Quantas turmas existem?",
+        "a": "Apenas uma turma por semestre."
+      },
+      {
+        "q": "Preciso saber programar?",
+        "a": "Não. O programa é focado em quem está começando e não exige conhecimento prévio."
+      },
+      {
+        "q": "Onde acontecem as aulas?",
+        "a": "No Centro de Informática (CI) da UFPB."
+      },
+      {
+        "q": "É gratuito?",
+        "a": "Sim — completamente gratuito."
+      },
+      {
+        "q": "Qual a cor favorita de Tiago?",
+        "a": "Uma das perguntas mais frequentes no Trilha, e a cor favorita de Tiago é ",
+        "easterEgg": "tiagoColor"
+      }
     ],
     "colors": {
       "sunday": "Vermelho",
@@ -199,7 +284,11 @@
     "contact": "Contato",
     "sections": "Seções",
     "locationLabel": "Localização",
-    "locationLines": ["UFPB · Centro de Informática", "João Pessoa, Paraíba", "Brasil"],
+    "locationLines": [
+      "UFPB · Centro de Informática",
+      "João Pessoa, Paraíba",
+      "Brasil"
+    ],
     "rights": "Todos os direitos reservados."
   },
   "turmaPage": {
@@ -223,117 +312,276 @@
     "submeterTitle": "Submissão",
     "items": [
       {
-        "number": "01",
-        "title": "Python Básico 1",
-        "description": "Variáveis, tipos primitivos, operadores e primeiros scripts. A base para escrever qualquer programa em Python.",
+        "number": "03",
+        "category": "python",
+        "title": "Variáveis e Fundamentos",
+        "description": "Introdução ao ambiente de execução, variáveis e fundamentos, tipos de dados, operações e estruturas condicionais.",
         "embedUrl": "https://www.canva.com/design/DAHBCocu1jA/oOEHWdZww_tgWoTxUAPKsA/view?embed",
         "canvaUrl": "https://www.canva.com/design/DAHBCocu1jA/oOEHWdZww_tgWoTxUAPKsA/view?utm_content=DAHBCocu1jA&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
         "date": "12 de junho de 2026",
         "deadline": "18 de junho de 2026",
         "homework": "Crie dois programas: (1) um que leia o nome, a idade e a cidade do usuário e imprima uma saudação personalizada; (2) outro que leia um número inteiro e diga se ele é positivo, negativo ou zero. Envie os dois arquivos .py num repositório do GitHub.",
         "links": [
-          { "label": "Documentação oficial Python 3", "url": "https://docs.python.org/3/tutorial/index.html" },
-          { "label": "Python Tutor — visualize a execução do seu código", "url": "https://pythontutor.com/" },
-          { "label": "W3Schools — Python Basics", "url": "https://www.w3schools.com/python/python_intro.asp" }
-        ]
+          {
+            "label": "Documentação oficial Python 3",
+            "url": "https://docs.python.org/3/tutorial/index.html"
+          },
+          {
+            "label": "Python Tutor — visualize a execução do seu código",
+            "url": "https://pythontutor.com/"
+          },
+          {
+            "label": "W3Schools — Python Basics",
+            "url": "https://www.w3schools.com/python/python_intro.asp"
+          }
+        ],
+        "dateISO": "2026-06-12"
       },
       {
-        "number": "02",
-        "title": "Python Básico 2",
-        "description": "Condicionais, laços e lógica de controle de fluxo. Como estruturar a lógica de um programa do começo ao fim.",
+        "number": "04",
+        "category": "python",
+        "title": "Laços de Repetição e Funções",
+        "description": "Laços de repetição e funções. Como estruturar a lógica de um programa do começo ao fim.",
         "embedUrl": "https://www.canva.com/design/DAHBCrdmSq4/EQXDzhpmoiq5MxbrOYGH7A/view?embed",
         "canvaUrl": "https://www.canva.com/design/DAHBCrdmSq4/EQXDzhpmoiq5MxbrOYGH7A/view?utm_content=DAHBCrdmSq4&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
         "date": "19 de junho de 2026",
         "deadline": "25 de junho de 2026",
         "homework": "Crie uma função que calcule o fatorial de um número usando laço de repetição. Em seguida, crie um programa que imprima os primeiros N termos da sequência de Fibonacci, onde N é lido do usuário. Envie os dois arquivos .py num repositório do GitHub.",
         "links": [
-          { "label": "Python — controle de fluxo", "url": "https://docs.python.org/3/tutorial/controlflow.html" },
-          { "label": "Python — funções definidas pelo usuário", "url": "https://docs.python.org/3/tutorial/controlflow.html#defining-functions" },
-          { "label": "Exercícios práticos — HackerRank Python", "url": "https://www.hackerrank.com/domains/python" }
-        ]
+          {
+            "label": "Python — controle de fluxo",
+            "url": "https://docs.python.org/3/tutorial/controlflow.html"
+          },
+          {
+            "label": "Python — funções definidas pelo usuário",
+            "url": "https://docs.python.org/3/tutorial/controlflow.html#defining-functions"
+          },
+          {
+            "label": "Exercícios práticos — HackerRank Python",
+            "url": "https://www.hackerrank.com/domains/python"
+          }
+        ],
+        "dateISO": "2026-06-19"
       },
       {
-        "number": "03",
-        "title": "Python Básico 3 — POO",
-        "description": "Orientação a objetos na prática: classes, atributos, métodos e herança. Como modelar problemas reais com objetos.",
-        "embedUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?utm_content=DAHAjlieHS0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
-        "date": "3 de julho de 2026",
-        "deadline": "9 de julho de 2026",
-        "homework": "Tarefa em breve.",
-        "links": [
-          { "label": "Python — classes e objetos", "url": "https://docs.python.org/3/tutorial/classes.html" }
-        ]
-      },
-      {
-        "number": "04",
-        "title": "Python Básico 3 — Frameworks e Bibliotecas",
-        "description": "O ecossistema Python: pip, ambientes virtuais e as bibliotecas que todo desenvolvedor precisa conhecer.",
+        "number": "05",
+        "category": "python",
+        "title": "Erros, Exceções e Frameworks",
+        "description": "Erros, exceções, arquivos, bibliotecas e frameworks. O ecossistema Python e como usá-lo na prática.",
         "embedUrl": "https://www.canva.com/design/DAHBClIMRP8/9kIAewlHHH-pK44YeYLSxw/view?embed",
         "canvaUrl": "https://www.canva.com/design/DAHBClIMRP8/9kIAewlHHH-pK44YeYLSxw/view?utm_content=DAHBClIMRP8&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
         "date": "26 de junho de 2026",
         "deadline": "2 de julho de 2026",
         "homework": "Crie um ambiente virtual com venv, instale a biblioteca requests e use-a para buscar dados de uma API pública (sugestão: https://jsonplaceholder.typicode.com/posts). Imprima o título dos 5 primeiros posts. Documente o processo num README.md e envie tudo no GitHub.",
         "links": [
-          { "label": "pip — gerenciador de pacotes Python", "url": "https://pip.pypa.io/en/stable/" },
-          { "label": "Documentação requests", "url": "https://requests.readthedocs.io/en/latest/" },
-          { "label": "JSONPlaceholder — API de teste gratuita", "url": "https://jsonplaceholder.typicode.com/" },
-          { "label": "Python venv — ambientes virtuais", "url": "https://docs.python.org/3/library/venv.html" }
-        ]
-      },
-      {
-        "number": "05",
-        "title": "Dados 1 — Introdução e Engenharia de Dados",
-        "description": "O que é engenharia de dados, pipelines e como dados brutos viram informação utilizável em sistemas reais.",
-        "embedUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?utm_content=DAHLV2G9YO0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
-        "homework": "Tarefa em breve.",
-        "links": []
+          {
+            "label": "pip — gerenciador de pacotes Python",
+            "url": "https://pip.pypa.io/en/stable/"
+          },
+          {
+            "label": "Documentação requests",
+            "url": "https://requests.readthedocs.io/en/latest/"
+          },
+          {
+            "label": "JSONPlaceholder — API de teste gratuita",
+            "url": "https://jsonplaceholder.typicode.com/"
+          },
+          {
+            "label": "Python venv — ambientes virtuais",
+            "url": "https://docs.python.org/3/library/venv.html"
+          }
+        ],
+        "dateISO": "2026-06-26"
       },
       {
         "number": "06",
-        "title": "Dados 2 — Análise de Dados",
-        "description": "Exploração e visualização com pandas e matplotlib. Como extrair padrões e insights de conjuntos de dados.",
-        "embedUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?utm_content=DAHBCznivZs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "category": "python",
+        "title": "Programação Orientada a Objetos",
+        "description": "Programação orientada a objetos: classes, atributos, métodos e herança.",
+        "embedUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?utm_content=DAHAjlieHS0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "3 de julho de 2026",
+        "deadline": "9 de julho de 2026",
         "homework": "Tarefa em breve.",
-        "links": []
+        "links": [
+          {
+            "label": "Python — classes e objetos",
+            "url": "https://docs.python.org/3/tutorial/classes.html"
+          }
+        ],
+        "dateISO": "2026-07-03"
       },
       {
         "number": "07",
-        "title": "Dados 3 — ML",
-        "description": "Introdução ao Machine Learning: modelos supervisionados, treino, teste e como avaliar performance na prática.",
-        "embedUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?utm_content=DAHAHCMaCH0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "category": "python",
+        "title": "Listas, Filas e Pilhas",
+        "description": "Estruturas lineares: arrays/listas, filas e pilhas. Como armazenar e organizar dados em memória.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "10 de julho de 2026",
+        "deadline": "16 de julho de 2026",
         "homework": "Tarefa em breve.",
-        "links": []
+        "links": [],
+        "dateISO": "2026-07-10"
       },
       {
         "number": "08",
-        "title": "FullStack 1 — Backend",
-        "description": "Como construir APIs RESTful com Python. Rotas, requisições, respostas e a lógica que vive no servidor.",
-        "embedUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?utm_content=DAHCdA8c7fI&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "category": "python",
+        "title": "Hash, Sets e Complexidade",
+        "description": "Tabelas hash, sets e complexidade computacional. Eficiência e escolha da estrutura certa para cada problema.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "17 de julho de 2026",
+        "deadline": "23 de julho de 2026",
         "homework": "Tarefa em breve.",
-        "links": []
+        "links": [],
+        "dateISO": "2026-07-17"
       },
       {
         "number": "09",
-        "title": "FullStack 2 — Banco de Dados",
-        "description": "Modelagem relacional, SQL e como conectar um banco de dados ao backend. Persistência de dados na prática.",
-        "embedUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?embed",
-        "canvaUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?utm_content=DAHBC_b0Jbs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
-        "homework": "Tarefa em breve.",
-        "links": []
+        "category": "python",
+        "title": "Prática em Competição",
+        "description": "Aula prática em formato de competição. O mini-projeto integra tudo que você aprendeu sobre estruturas de dados.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "24 de julho de 2026",
+        "deadline": "30 de julho de 2026",
+        "taskType": "miniprojeto",
+        "homework": "Mini-Projeto em breve.",
+        "links": [],
+        "dateISO": "2026-07-24"
       },
       {
         "number": "10",
-        "title": "FullStack 3 — Frontend",
-        "description": "HTML, CSS e JavaScript aplicados: como construir interfaces que conversam com o backend e fazem sentido pro usuário.",
+        "category": "dados",
+        "title": "Engenharia de Dados e Web Scraping",
+        "description": "Introdução à engenharia de dados e web scraping na prática. Como coletar, processar e transformar dados brutos.",
+        "embedUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?utm_content=DAHLV2G9YO0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "31 de julho de 2026",
+        "deadline": "6 de agosto de 2026",
+        "homework": "Tarefa em breve.",
+        "links": [],
+        "dateISO": "2026-07-31"
+      },
+      {
+        "number": "11",
+        "category": "dados",
+        "title": "Análise Exploratória de Dados",
+        "description": "Conceitos e prática de análise exploratória de dados com pandas e matplotlib.",
+        "embedUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?utm_content=DAHBCznivZs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "7 de agosto de 2026",
+        "deadline": "27 de agosto de 2026",
+        "homework": "Tarefa em breve.",
+        "links": [],
+        "dateISO": "2026-08-07"
+      },
+      {
+        "number": "12",
+        "category": "dados",
+        "title": "Apresentação dos Notebooks",
+        "description": "Apresentação e discussão dos notebooks desenvolvidos na tarefa anterior. Refinamento e insights.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "28 de agosto de 2026",
+        "deadline": "3 de setembro de 2026",
+        "homework": "Tarefa em breve.",
+        "links": [],
+        "dateISO": "2026-08-28"
+      },
+      {
+        "number": "13",
+        "category": "dados",
+        "title": "Introdução ao Machine Learning",
+        "description": "Introdução ao Machine Learning: modelos supervisionados, treino, teste e avaliação de performance.",
+        "embedUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?utm_content=DAHAHCMaCH0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "4 de setembro de 2026",
+        "deadline": "10 de setembro de 2026",
+        "homework": "Tarefa em breve.",
+        "links": [],
+        "dateISO": "2026-09-04"
+      },
+      {
+        "number": "14",
+        "category": "dados",
+        "title": "Tópicos Avançados de ML",
+        "description": "Tópicos avançados e mini-projeto de Machine Learning. Como aplicar modelos em problemas reais.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "11 de setembro de 2026",
+        "deadline": "17 de setembro de 2026",
+        "taskType": "miniprojeto",
+        "homework": "Mini-Projeto em breve.",
+        "links": [],
+        "dateISO": "2026-09-11"
+      },
+      {
+        "number": "15",
+        "category": "fullstack",
+        "title": "Introdução ao Full Stack",
+        "description": "Introdução ao desenvolvimento full stack: o que é um software, redes e os fundamentos de APIs.",
+        "embedUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?utm_content=DAHCdA8c7fI&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "18 de setembro de 2026",
+        "deadline": "24 de setembro de 2026",
+        "homework": "Tarefa em breve.",
+        "links": [],
+        "dateISO": "2026-09-18"
+      },
+      {
+        "number": "16",
+        "category": "fullstack",
+        "title": "API com FastAPI e Postman",
+        "description": "Finalização do backend na prática: API com FastAPI e Postman. Como persistir dados de forma durável.",
+        "embedUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?utm_content=DAHBC_b0Jbs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "25 de setembro de 2026",
+        "deadline": "1 de outubro de 2026",
+        "homework": "Tarefa em breve.",
+        "links": [],
+        "dateISO": "2026-09-25"
+      },
+      {
+        "number": "17",
+        "category": "fullstack",
+        "title": "Banco de Dados",
+        "description": "Banco de dados teórico: modelagem relacional, SQL e como conectar dados ao servidor.",
         "embedUrl": "https://www.canva.com/design/DAHIPYNNMlM/gZ7J69hsNILgyqoOJsBing/view?embed",
         "canvaUrl": "https://www.canva.com/design/DAHIPYNNMlM/gZ7J69hsNILgyqoOJsBing/view?utm_content=DAHIPYNNMlM&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "2 de outubro de 2026",
+        "deadline": "8 de outubro de 2026",
         "homework": "Tarefa em breve.",
-        "links": []
+        "links": [],
+        "dateISO": "2026-10-02"
+      },
+      {
+        "number": "18",
+        "category": "fullstack",
+        "title": "SQLAlchemy e Integração de Banco",
+        "description": "Aprimoramento da API com schemas, base models e SQLAlchemy. Integração completa do banco ao backend.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "9 de outubro de 2026",
+        "deadline": "15 de outubro de 2026",
+        "homework": "Tarefa em breve.",
+        "links": [],
+        "dateISO": "2026-10-09"
+      },
+      {
+        "number": "19",
+        "category": "fullstack",
+        "title": "Frontend na Prática",
+        "description": "Teoria e prática de frontend. O mini-projeto fecha o ciclo com uma aplicação completa.",
+        "embedUrl": "",
+        "canvaUrl": "",
+        "date": "16 de outubro de 2026",
+        "deadline": "24 de outubro de 2026",
+        "taskType": "miniprojeto",
+        "homework": "Mini-Projeto em breve.",
+        "links": [],
+        "dateISO": "2026-10-16"
       }
     ],
     "form": {
@@ -353,7 +601,17 @@
       "notesPlaceholder": "Alguma observação sobre sua solução? (opcional)",
       "sending": "Enviando...",
       "successTitle": "Tarefa enviada!",
-      "successBody": "Recebemos sua entrega. O time vai dar um retorno em breve."
-    }
+      "successBody": "Recebemos sua entrega. O time vai dar um retorno em breve.",
+      "errorRequired": "Preencha todos os campos obrigatórios.",
+      "errorGithub": "O link da tarefa deve ser do GitHub (https://github.com/...)."
+    },
+    "miniprojetoTitle": "Mini-Projeto",
+    "categories": {
+      "python": "Python Básico",
+      "dados": "Dados",
+      "fullstack": "FullStack",
+      "pitch": "Pitch"
+    },
+    "today": "Hoje"
   }
 }

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -9,7 +9,8 @@
     "projetos": "Projetos",
     "time": "Time",
     "materiais": "Materiais",
-    "artigos": "Artigos"
+    "artigos": "Artigos",
+    "aulas": "Aulas"
   },
   "hero": {
     "eyebrow": "Trilha",
@@ -204,5 +205,155 @@
   "turmaPage": {
     "back": "← Voltar",
     "cohortLabel": "Turma"
+  },
+  "aulas": {
+    "eyebrow": "Aulas",
+    "title": "Aulas do Trilha.",
+    "lede": "Acesse as gravações e materiais de cada aula do semestre. Ficou com dúvida? Envie sua mensagem direto para o time.",
+    "lessonLabel": "Aula",
+    "comingSoon": "Em breve",
+    "available": "Disponível",
+    "dateLabel": "Data",
+    "deadlineLabel": "Prazo",
+    "back": "Todas as aulas",
+    "aboutTitle": "Sobre esta aula",
+    "linksTitle": "Materiais úteis",
+    "homeworkTitle": "Tarefa",
+    "descricaoTitle": "Descrição",
+    "submeterTitle": "Submissão",
+    "items": [
+      {
+        "number": "01",
+        "title": "Python Básico 1",
+        "description": "Variáveis, tipos primitivos, operadores e primeiros scripts. A base para escrever qualquer programa em Python.",
+        "embedUrl": "https://www.canva.com/design/DAHBCocu1jA/oOEHWdZww_tgWoTxUAPKsA/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBCocu1jA/oOEHWdZww_tgWoTxUAPKsA/view?utm_content=DAHBCocu1jA&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "12 de junho de 2026",
+        "deadline": "18 de junho de 2026",
+        "homework": "Crie dois programas: (1) um que leia o nome, a idade e a cidade do usuário e imprima uma saudação personalizada; (2) outro que leia um número inteiro e diga se ele é positivo, negativo ou zero. Envie os dois arquivos .py num repositório do GitHub.",
+        "links": [
+          { "label": "Documentação oficial Python 3", "url": "https://docs.python.org/3/tutorial/index.html" },
+          { "label": "Python Tutor — visualize a execução do seu código", "url": "https://pythontutor.com/" },
+          { "label": "W3Schools — Python Basics", "url": "https://www.w3schools.com/python/python_intro.asp" }
+        ]
+      },
+      {
+        "number": "02",
+        "title": "Python Básico 2",
+        "description": "Condicionais, laços e lógica de controle de fluxo. Como estruturar a lógica de um programa do começo ao fim.",
+        "embedUrl": "https://www.canva.com/design/DAHBCrdmSq4/EQXDzhpmoiq5MxbrOYGH7A/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBCrdmSq4/EQXDzhpmoiq5MxbrOYGH7A/view?utm_content=DAHBCrdmSq4&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "19 de junho de 2026",
+        "deadline": "25 de junho de 2026",
+        "homework": "Crie uma função que calcule o fatorial de um número usando laço de repetição. Em seguida, crie um programa que imprima os primeiros N termos da sequência de Fibonacci, onde N é lido do usuário. Envie os dois arquivos .py num repositório do GitHub.",
+        "links": [
+          { "label": "Python — controle de fluxo", "url": "https://docs.python.org/3/tutorial/controlflow.html" },
+          { "label": "Python — funções definidas pelo usuário", "url": "https://docs.python.org/3/tutorial/controlflow.html#defining-functions" },
+          { "label": "Exercícios práticos — HackerRank Python", "url": "https://www.hackerrank.com/domains/python" }
+        ]
+      },
+      {
+        "number": "03",
+        "title": "Python Básico 3 — POO",
+        "description": "Orientação a objetos na prática: classes, atributos, métodos e herança. Como modelar problemas reais com objetos.",
+        "embedUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHAjlieHS0/0triK2_jCcUBGhC7yYWbCw/view?utm_content=DAHAjlieHS0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "3 de julho de 2026",
+        "deadline": "9 de julho de 2026",
+        "homework": "Tarefa em breve.",
+        "links": [
+          { "label": "Python — classes e objetos", "url": "https://docs.python.org/3/tutorial/classes.html" }
+        ]
+      },
+      {
+        "number": "04",
+        "title": "Python Básico 3 — Frameworks e Bibliotecas",
+        "description": "O ecossistema Python: pip, ambientes virtuais e as bibliotecas que todo desenvolvedor precisa conhecer.",
+        "embedUrl": "https://www.canva.com/design/DAHBClIMRP8/9kIAewlHHH-pK44YeYLSxw/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBClIMRP8/9kIAewlHHH-pK44YeYLSxw/view?utm_content=DAHBClIMRP8&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "date": "26 de junho de 2026",
+        "deadline": "2 de julho de 2026",
+        "homework": "Crie um ambiente virtual com venv, instale a biblioteca requests e use-a para buscar dados de uma API pública (sugestão: https://jsonplaceholder.typicode.com/posts). Imprima o título dos 5 primeiros posts. Documente o processo num README.md e envie tudo no GitHub.",
+        "links": [
+          { "label": "pip — gerenciador de pacotes Python", "url": "https://pip.pypa.io/en/stable/" },
+          { "label": "Documentação requests", "url": "https://requests.readthedocs.io/en/latest/" },
+          { "label": "JSONPlaceholder — API de teste gratuita", "url": "https://jsonplaceholder.typicode.com/" },
+          { "label": "Python venv — ambientes virtuais", "url": "https://docs.python.org/3/library/venv.html" }
+        ]
+      },
+      {
+        "number": "05",
+        "title": "Dados 1 — Introdução e Engenharia de Dados",
+        "description": "O que é engenharia de dados, pipelines e como dados brutos viram informação utilizável em sistemas reais.",
+        "embedUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHLV2G9YO0/5bx-5OZsT2mNbsUo6jxHzw/view?utm_content=DAHLV2G9YO0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Tarefa em breve.",
+        "links": []
+      },
+      {
+        "number": "06",
+        "title": "Dados 2 — Análise de Dados",
+        "description": "Exploração e visualização com pandas e matplotlib. Como extrair padrões e insights de conjuntos de dados.",
+        "embedUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBCznivZs/KwjP6zx1W-DSx_kOyn6dUg/view?utm_content=DAHBCznivZs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Tarefa em breve.",
+        "links": []
+      },
+      {
+        "number": "07",
+        "title": "Dados 3 — ML",
+        "description": "Introdução ao Machine Learning: modelos supervisionados, treino, teste e como avaliar performance na prática.",
+        "embedUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHAHCMaCH0/PyXe12SA5RgEn51XZqCOFA/view?utm_content=DAHAHCMaCH0&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Tarefa em breve.",
+        "links": []
+      },
+      {
+        "number": "08",
+        "title": "FullStack 1 — Backend",
+        "description": "Como construir APIs RESTful com Python. Rotas, requisições, respostas e a lógica que vive no servidor.",
+        "embedUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHCdA8c7fI/k5WabounCxuqTjFHPnMi2g/view?utm_content=DAHCdA8c7fI&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Tarefa em breve.",
+        "links": []
+      },
+      {
+        "number": "09",
+        "title": "FullStack 2 — Banco de Dados",
+        "description": "Modelagem relacional, SQL e como conectar um banco de dados ao backend. Persistência de dados na prática.",
+        "embedUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHBC_b0Jbs/JITXL1dnTa857Wn2z9XpJQ/view?utm_content=DAHBC_b0Jbs&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Tarefa em breve.",
+        "links": []
+      },
+      {
+        "number": "10",
+        "title": "FullStack 3 — Frontend",
+        "description": "HTML, CSS e JavaScript aplicados: como construir interfaces que conversam com o backend e fazem sentido pro usuário.",
+        "embedUrl": "https://www.canva.com/design/DAHIPYNNMlM/gZ7J69hsNILgyqoOJsBing/view?embed",
+        "canvaUrl": "https://www.canva.com/design/DAHIPYNNMlM/gZ7J69hsNILgyqoOJsBing/view?utm_content=DAHIPYNNMlM&utm_campaign=designshare&utm_medium=embeds&utm_source=link",
+        "homework": "Tarefa em breve.",
+        "links": []
+      }
+    ],
+    "form": {
+      "eyebrow": "Envio",
+      "submitTitle": "Enviar tarefa",
+      "submitLede": "Envie o link da sua solução e qualquer observação que achar relevante.",
+      "submitBtn": "Enviar tarefa",
+      "edicao": "Edição do Trilha",
+      "edicaoPlaceholder": "Selecione sua turma",
+      "name": "Nome",
+      "email": "E-mail",
+      "taskLink": "Link da tarefa",
+      "notes": "Observações",
+      "namePlaceholder": "Seu nome completo",
+      "emailPlaceholder": "seu@email.com",
+      "taskLinkPlaceholder": "https://github.com/seu-usuario/seu-repositorio",
+      "notesPlaceholder": "Alguma observação sobre sua solução? (opcional)",
+      "sending": "Enviando...",
+      "successTitle": "Tarefa enviada!",
+      "successBody": "Recebemos sua entrega. O time vai dar um retorno em breve."
+    }
   }
 }


### PR DESCRIPTION
- Add /aulas route with class schedule list (clickable cards with dates and deadlines)
- Add /aulas/[slug] individual class pages with Canva slide embed, homework description, and submission form
- Add Google Sheets integration via server-side API route (/api/submit-aula) keeping the URL private
- Add Trilha edition dropdown (2025.2–2027.2) to submission form
- Add Aulas nav item to NavBar
- Add full PT/EN translations for all aulas content including 10 classes with Canva embeds, dates, deadlines, homework assignments