### PR TITLE
feat(aulas): collapsible categories + search bar

### DIFF
--- a/src/app/aulas/page.tsx
+++ b/src/app/aulas/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
+import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from '@/hooks/useTranslation';
 
 type Aula = {
@@ -23,19 +25,79 @@ function getDateState(dateISO?: string): 'past' | 'today' | 'upcoming' {
   return 'upcoming';
 }
 
+function normalize(s: string) {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '');
+}
+
+function pickDefaultOpenCategory(aulas: Aula[]): string | null {
+  if (!aulas.length) return null;
+  const todayAula = aulas.find((a) => getDateState(a.dateISO) === 'today');
+  if (todayAula) return todayAula.category;
+  const upcomingAula = aulas.find((a) => getDateState(a.dateISO) === 'upcoming');
+  if (upcomingAula) return upcomingAula.category;
+  // all past — open the last category that has any aula
+  const lastWithDate = [...aulas].reverse().find((a) => a.dateISO);
+  return lastWithDate?.category ?? aulas[0].category;
+}
+
 export default function AulasPage() {
   const { t } = useTranslation();
   const aulas = t<Aula[]>('aulas.items');
   const categories = t<Record<string, string>>('aulas.categories');
+  const searchPlaceholder = t('aulas.searchPlaceholder');
+  const noResultsLabel = t('aulas.noResults');
 
-  const groups: { category: string; items: Aula[] }[] = [];
-  for (const aula of aulas) {
-    const last = groups[groups.length - 1];
-    if (last && last.category === aula.category) {
-      last.items.push(aula);
-    } else {
-      groups.push({ category: aula.category, items: [aula] });
+  const [query, setQuery] = useState('');
+  const [openCategories, setOpenCategories] = useState<Set<string>>(() => {
+    const initial = pickDefaultOpenCategory(aulas);
+    return new Set(initial ? [initial] : []);
+  });
+
+  const groups = useMemo(() => {
+    const out: { category: string; items: Aula[] }[] = [];
+    for (const aula of aulas) {
+      const last = out[out.length - 1];
+      if (last && last.category === aula.category) {
+        last.items.push(aula);
+      } else {
+        out.push({ category: aula.category, items: [aula] });
+      }
     }
+    return out;
+  }, [aulas]);
+
+  const trimmed = query.trim();
+  const isSearching = trimmed.length > 0;
+  const needle = normalize(trimmed);
+
+  const filteredGroups = useMemo(() => {
+    if (!isSearching) return groups;
+    return groups
+      .map((g) => ({
+        category: g.category,
+        items: g.items.filter((a) => {
+          const haystack = normalize(`${a.number} ${a.title} ${a.description}`);
+          return haystack.includes(needle);
+        }),
+      }))
+      .filter((g) => g.items.length > 0);
+  }, [groups, isSearching, needle]);
+
+  const totalMatches = useMemo(
+    () => filteredGroups.reduce((sum, g) => sum + g.items.length, 0),
+    [filteredGroups],
+  );
+
+  function toggleCategory(category: string) {
+    setOpenCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) next.delete(category);
+      else next.add(category);
+      return next;
+    });
   }
 
   return (
@@ -47,65 +109,129 @@ export default function AulasPage() {
           <p className="lede">{t('aulas.lede')}</p>
         </header>
 
-        <div className="aulas-schedule">
-          {groups.map(({ category, items }) => {
-            const categoryLabel = categories?.[category] ?? category;
-            return (
-              <div key={category} className="aulas-group">
-                <div className={`aulas-group-header aulas-group-header--${category}`}>
-                  <span className="aulas-group-label">{categoryLabel}</span>
-                </div>
-                {items.map((aula) => {
-                  const hasSlide = Boolean(aula.embedUrl);
-                  const isMini = aula.taskType === 'miniprojeto';
-                  const dateState = getDateState(aula.dateISO);
-                  return (
-                    <Link
-                      key={aula.number}
-                      href={`/aulas/${aula.number}`}
-                      className={`aula-scard aula-scard--${dateState}`}
-                    >
-                      <div className="aula-scard-num">
-                        <span>{aula.number}</span>
-                      </div>
-
-                      <div className="aula-scard-body">
-                        <div className="aula-scard-title-row">
-                          <h3 className="aula-scard-title">{aula.title}</h3>
-                          {dateState === 'today' && (
-                            <span className="aula-scard-today-tag">{t('aulas.today')}</span>
-                          )}
-                          {isMini && <span className="aula-scard-mini-tag">Mini-Projeto</span>}
-                        </div>
-                        <p className="aula-scard-desc">{aula.description}</p>
-                      </div>
-
-                      <div className="aula-scard-right">
-                        {aula.date ? (
-                          <div className="aula-scard-dates">
-                            <span className="aula-scard-date">{aula.date}</span>
-                            {aula.deadline && (
-                              <span className="aula-scard-deadline">
-                                {t('aulas.deadlineLabel')}: {aula.deadline}
-                              </span>
-                            )}
-                          </div>
-                        ) : (
-                          <span className="aula-scard-soon">{t('aulas.comingSoon')}</span>
-                        )}
-                        <span className={`aula-scard-status ${hasSlide ? 'aula-scard-status--on' : ''}`}>
-                          {hasSlide ? t('aulas.available') : t('aulas.comingSoon')}
-                        </span>
-                      </div>
-
-                      <span className="aula-scard-arrow">→</span>
-                    </Link>
-                  );
-                })}
-              </div>
-            );
-          })}
+        <div className="aulas-search">
+          <span className="aulas-search-icon" aria-hidden="true">
+            <svg viewBox="0 0 20 20" fill="none" width="18" height="18">
+              <circle cx="9" cy="9" r="6" stroke="currentColor" strokeWidth="1.6" />
+              <path d="M14 14L17 17" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+            </svg>
+          </span>
+          <input
+            type="search"
+            className="aulas-search-input"
+            placeholder={searchPlaceholder}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label={searchPlaceholder}
+          />
+          {isSearching && (
+            <button
+              type="button"
+              className="aulas-search-clear"
+              onClick={() => setQuery('')}
+              aria-label={t('aulas.clearSearch')}
+            >
+              ✕
+            </button>
+          )}
         </div>
+
+        {isSearching && totalMatches === 0 ? (
+          <p className="aulas-empty">{noResultsLabel.replace('{q}', trimmed)}</p>
+        ) : (
+          <div className="aulas-schedule">
+            {filteredGroups.map(({ category, items }) => {
+              const categoryLabel = categories?.[category] ?? category;
+              const isOpen = isSearching || openCategories.has(category);
+              const totalInCategory = groups.find((g) => g.category === category)?.items.length ?? items.length;
+              const countLabel = isSearching && items.length !== totalInCategory
+                ? `${items.length} de ${totalInCategory}`
+                : `${items.length} ${items.length === 1 ? t('aulas.lessonSingular') : t('aulas.lessonPlural')}`;
+              return (
+                <div key={category} className="aulas-group">
+                  <button
+                    type="button"
+                    className={`aulas-group-header aulas-group-header--${category}${isOpen ? ' is-open' : ''}`}
+                    onClick={() => toggleCategory(category)}
+                    aria-expanded={isOpen}
+                    aria-controls={`aulas-group-body-${category}`}
+                  >
+                    <span className="aulas-group-chevron" aria-hidden="true">
+                      <svg viewBox="0 0 12 12" width="10" height="10" fill="none">
+                        <path d="M3 1.5L8 6L3 10.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </span>
+                    <span className="aulas-group-label">{categoryLabel}</span>
+                    <span className="aulas-group-count">{countLabel}</span>
+                  </button>
+                  <AnimatePresence initial={false}>
+                    {isOpen && (
+                      <motion.div
+                        id={`aulas-group-body-${category}`}
+                        className="aulas-group-body"
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: 'auto', opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.28, ease: [0.2, 0.8, 0.3, 1] }}
+                        style={{ overflow: 'hidden' }}
+                      >
+                        <div className="aulas-group-inner">
+                          {items.map((aula) => {
+                            const hasSlide = Boolean(aula.embedUrl);
+                            const isMini = aula.taskType === 'miniprojeto';
+                            const dateState = getDateState(aula.dateISO);
+                            return (
+                              <Link
+                                key={aula.number}
+                                href={`/aulas/${aula.number}`}
+                                className={`aula-scard aula-scard--${dateState}`}
+                              >
+                                <div className="aula-scard-num">
+                                  <span>{aula.number}</span>
+                                </div>
+
+                                <div className="aula-scard-body">
+                                  <div className="aula-scard-title-row">
+                                    <h3 className="aula-scard-title">{aula.title}</h3>
+                                    {dateState === 'today' && (
+                                      <span className="aula-scard-today-tag">{t('aulas.today')}</span>
+                                    )}
+                                    {isMini && <span className="aula-scard-mini-tag">Mini-Projeto</span>}
+                                  </div>
+                                  <p className="aula-scard-desc">{aula.description}</p>
+                                </div>
+
+                                <div className="aula-scard-right">
+                                  {aula.date ? (
+                                    <div className="aula-scard-dates">
+                                      <span className="aula-scard-date">{aula.date}</span>
+                                      {aula.deadline && (
+                                        <span className="aula-scard-deadline">
+                                          {t('aulas.deadlineLabel')}: {aula.deadline}
+                                        </span>
+                                      )}
+                                    </div>
+                                  ) : (
+                                    <span className="aula-scard-soon">{t('aulas.comingSoon')}</span>
+                                  )}
+                                  <span className={`aula-scard-status ${hasSlide ? 'aula-scard-status--on' : ''}`}>
+                                    {hasSlide ? t('aulas.available') : t('aulas.comingSoon')}
+                                  </span>
+                                </div>
+
+                                <span className="aula-scard-arrow">→</span>
+                              </Link>
+                            );
+                          })}
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -770,11 +770,70 @@ button { font-family: inherit; cursor: pointer; }
 .faq-a { margin: 0 0 24px; max-width: 60ch; color: var(--ink-soft); font-size: 16px; }
 
 /* AULAS — SCHEDULE LIST (main /aulas page) */
+.aulas-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 40px;
+  padding: 14px 18px;
+  background: var(--cream);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-s);
+  transition: border-color .2s ease, box-shadow .2s ease;
+}
+.aulas-search:focus-within {
+  border-color: var(--mint-deep);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--mint-deep) 18%, transparent);
+}
+.aulas-search-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-soft);
+  flex-shrink: 0;
+}
+.aulas-search-input {
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font: inherit;
+  font-size: 15px;
+  color: var(--ink);
+  min-width: 0;
+}
+.aulas-search-input::placeholder { color: var(--ink-soft); opacity: 0.7; }
+.aulas-search-input::-webkit-search-cancel-button { display: none; }
+.aulas-search-clear {
+  border: 0;
+  background: transparent;
+  color: var(--ink-soft);
+  font-size: 14px;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background .15s ease, color .15s ease;
+}
+.aulas-search-clear:hover { background: color-mix(in srgb, var(--ink) 8%, transparent); color: var(--ink); }
+.aulas-empty {
+  margin: 56px 0 24px;
+  padding: 32px 24px;
+  border: 1px dashed var(--rule);
+  border-radius: var(--radius-s);
+  text-align: center;
+  color: var(--ink-soft);
+  font-size: 15px;
+}
 .aulas-schedule {
   display: flex;
   flex-direction: column;
-  margin-top: 56px;
-  border-top: 1px solid var(--rule);
+  margin-top: 32px;
 }
 .aula-scard {
   display: grid;
@@ -852,13 +911,34 @@ button { font-family: inherit; cursor: pointer; }
 }
 
 /* Category group — schedule list */
-.aulas-group { display: contents; }
+.aulas-group { display: block; border-bottom: 1px solid var(--rule); }
+.aulas-group:first-child { border-top: 1px solid var(--rule); }
 .aulas-group-header {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 28px 0 4px;
+  padding: 24px 0;
+  width: 100%;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  transition: background .15s ease;
 }
+.aulas-group-header:hover { background: color-mix(in srgb, var(--ink) 3%, transparent); margin-inline: -24px; padding-inline: 24px; border-radius: var(--radius-s); }
+.aulas-group-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--ink-soft);
+  transition: transform .25s cubic-bezier(.2,.8,.3,1);
+  flex-shrink: 0;
+}
+.aulas-group-header.is-open .aulas-group-chevron { transform: rotate(90deg); }
 .aulas-group-label {
   font-family: var(--font-mono);
   font-size: 11px;
@@ -868,10 +948,26 @@ button { font-family: inherit; cursor: pointer; }
   padding: 5px 12px;
   border-radius: 6px;
 }
+.aulas-group-count {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--ink-soft);
+  opacity: 0.7;
+  text-transform: uppercase;
+}
 .aulas-group-header--python  .aulas-group-label { background: rgba(55, 118, 171, 0.1); color: #2a6396; }
 .aulas-group-header--dados   .aulas-group-label { background: rgba(219, 121, 40, 0.1); color: #b3621c; }
 .aulas-group-header--fullstack .aulas-group-label { background: rgba(16, 148, 130, 0.1); color: #0e7a6c; }
 .aulas-group-header--pitch   .aulas-group-label { background: rgba(100, 80, 160, 0.1); color: #5b3fa8; }
+.aulas-group-body { width: 100%; }
+.aulas-group-inner {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--rule);
+}
+.aulas-group-inner .aula-scard:last-child { border-bottom: 0; }
 
 /* Title + mini-projeto tag on the same row */
 .aula-scard-title-row { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -620,6 +620,11 @@
       "fullstack": "FullStack",
       "pitch": "Pitch"
     },
-    "today": "Today"
+    "today": "Today",
+    "searchPlaceholder": "Search lessons by title, number or description",
+    "clearSearch": "Clear search",
+    "noResults": "No lessons found for “{q}”.",
+    "lessonSingular": "lesson",
+    "lessonPlural": "lessons"
   }
 }

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -619,6 +619,11 @@
       "fullstack": "FullStack",
       "pitch": "Pitch"
     },
-    "today": "Hoje"
+    "today": "Hoje",
+    "searchPlaceholder": "Pesquisar aulas por título, número ou descrição",
+    "clearSearch": "Limpar busca",
+    "noResults": "Nenhuma aula encontrada para “{q}”.",
+    "lessonSingular": "aula",
+    "lessonPlural": "aulas"
   }
 }


### PR DESCRIPTION
## Why

The Aulas page now has 17 lessons across 4 categories and growing. The flat list made it hard to scan — students had to scroll past everything to find what they cared about, and there was no way to jump to a specific lesson by name. Compacting the categories and adding a search keeps the page navigable as more semesters land.

## What

https://github.com/user-attachments/assets/b49f1bc4-2af6-4daa-aad5-fb9ed965753b

