### PR TITLE
fix(aulas): limit turma options to active editions

### DIFF
--- a/src/app/aulas/[slug]/page.tsx
+++ b/src/app/aulas/[slug]/page.tsx
@@ -27,7 +27,7 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
   const categories = t<Record<string, string>>('aulas.categories');
   const aula = aulas.find((a) => a.number === slug);
 
-  const [edicao, setEdicao] = useState('');
+  const [edicao, setEdicao] = useState('2026.1');
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [taskLink, setTaskLink] = useState('');
@@ -36,7 +36,7 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
   const [sending, setSending] = useState(false);
   const [formError, setFormError] = useState('');
 
-  const edicoes = ['2025.2', '2026.1', '2026.2', '2027.1', '2027.2'];
+  const edicoes = ['2025.2', '2026.1'];
 
   if (!aula) return null;
 


### PR DESCRIPTION
## Why

A turma 2026.1 já está em andamento, então o seletor de turma no formulário de submissão de tarefa não precisa listar edições futuras. As opções extras (2026.2, 2027.1, 2027.2) só geravam ruído e a possibilidade de o aluno selecionar uma turma inexistente.

## What

- Reduz `edicoes` para apenas `['2025.2', '2026.1']`.
- Define `2026.1` como valor padrão do estado `edicao`, em vez do placeholder vazio "Selecione sua turma".

## File

- `src/app/aulas/[slug]/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)