### PR TITLE
fix(aulas): corrige tag "HOJE" adiantada perto da meia-noite

### DIFF
--- a/src/app/aulas/page.tsx
+++ b/src/app/aulas/page.tsx
@@ -19,7 +19,9 @@ type Aula = {
 
 function getDateState(dateISO?: string): 'past' | 'today' | 'upcoming' {
   if (!dateISO) return 'upcoming';
-  const today = new Date().toISOString().slice(0, 10);
+  const today = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Sao_Paulo',
+  }).format(new Date());
   if (dateISO < today) return 'past';
   if (dateISO === today) return 'today';
   return 'upcoming';


### PR DESCRIPTION
## Problema

A tag **HOJE** nas aulas aparecia até 3 horas mais cedo. Toda noite, entre 21:00 e 23:59 (horário de Brasília), uma aula marcada para o *dia seguinte* já era exibida como HOJE.

## Causa

Em `getDateState` (`src/app/aulas/page.tsx`), o "hoje" era derivado de `new Date().toISOString()`, que retorna a data em **UTC**. Como o Brasil é UTC−3, nessa janela noturna o UTC já havia virado o dia seguinte, mesmo ainda sendo "hoje" no horário local.

| Horário local | UTC | `today` calculado |
|---|---|---|
| 11/jun 23:52 | 12/jun 02:52 | `2026-06-12` ❌ |

## Correção

Calcular o "hoje" no fuso `America/Sao_Paulo` com `Intl.DateTimeFormat` (locale `en-CA` para o formato `YYYY-MM-DD`), garantindo que a tag reflita sempre o dia do calendário brasileiro, independente de onde o visitante acesse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)