### PR TITLE
feat(aulas): aceitar link do Google Colab na submissão de tarefa por enquanto

### DIFF
--- a/src/app/aulas/[slug]/page.tsx
+++ b/src/app/aulas/[slug]/page.tsx
@@ -81,7 +81,10 @@ export default function AulaPage({ params }: { params: Promise<{ slug: string }>
       setFormError(t('aulas.form.errorRequired'));
       return;
     }
-    if (!taskLink.startsWith('https://github.com/')) {
+    if (
+      !taskLink.startsWith('https://github.com/') &&
+      !taskLink.startsWith('https://colab.research.google.com/')
+    ) {
       setFormError(t('aulas.form.errorGithub'));
       return;
     }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -652,7 +652,7 @@
       "successTitle": "Homework submitted!",
       "successBody": "We received your submission. The team will get back to you soon.",
       "errorRequired": "Please fill in all required fields.",
-      "errorGithub": "The homework link must be a GitHub URL (https://github.com/...)."
+      "errorGithub": "The homework link must be a GitHub URL (https://github.com/...) or a Google Colab URL (https://colab.research.google.com/...)."
     },
     "miniprojetoTitle": "Mini-Project",
     "categories": {

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -651,7 +651,7 @@
       "successTitle": "Tarefa enviada!",
       "successBody": "Recebemos sua entrega. O time vai dar um retorno em breve.",
       "errorRequired": "Preencha todos os campos obrigatórios.",
-      "errorGithub": "O link da tarefa deve ser do GitHub (https://github.com/...)."
+      "errorGithub": "O link da tarefa deve ser do GitHub (https://github.com/...) ou do Google Colab (https://colab.research.google.com/...)."
     },
     "miniprojetoTitle": "Mini-Projeto",
     "categories": {


### PR DESCRIPTION
## O que muda

Permite que a submissão de tarefas nas Aulas aceite links do **Google Colab** (`https://colab.research.google.com/...`) além do GitHub.

Mudança temporária até que os alunos tenham a aula de GitHub na **quarta, 17/06** — assim quem ainda não sabe usar GitHub pode enviar o notebook pelo Colab.

## Detalhes

- `src/app/aulas/[slug]/page.tsx` — validação do link agora aceita URLs do GitHub **ou** do Colab.
- `src/locales/pt/common.json` e `src/locales/en/common.json` — mensagem de erro atualizada para mencionar ambas as opções.

## Follow-up

Reverter a parte do Colab após a aula de GitHub (17/06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)